### PR TITLE
Package auto-dark-emacs better

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,30 @@ Wanna emacs to follow your MacOS Dark-mode on/off options?
 
 That's it. This program lets Emacs change between 2 user defined (in code) themes to be automatically changed when Dark Mode set on/off on MacOS.
 
-By default, themes are wombat and leuven, since these are packed togheter with Emacs.
+By default, themes are wombat and leuven, since these are packed together with Emacs.
 
 
 Install
 -------
-Simply copy the auto-dark-emacs.el file contents to your ~/.emacs file and restart emacs or eval the dot file.
 
+Simply copy the auto-dark-emacs.el file to `~/.emacs.d/vendor/auto-dark-emacs/auto-dark-emacs.el` (or clone this repository there), and then add the following to your `.emacs`:
+
+```
+(add-to-list 'load-path "~/.emacs.d/vendor/auto-dark-emacs/")
+(require 'auto-dark-emacs)
+```
 
 Usage
 -----
 Change your dark-mode settings on MacOS and let the magic happens :D
+
+Customization
+-----
+The light/dark themes can be customized using the Emacs customization system. `M-x customize-group auto-dark-emacs`.
+
+OSA Script fallback
+-----
+For terminal-based emacs, it is possible to check dark mode status using osascript rather than relying on the built-in Applescript support that GUI Emacs provides. To enable it, customize `dark-mode-emacs/allow-osascript` and set it to `t`.
 
 Screenshot
 ----------

--- a/auto-dark-emacs.el
+++ b/auto-dark-emacs.el
@@ -1,38 +1,93 @@
-;; Auto-Dark-Emacs is an auto changer between 2 themes, dark/light, respecting the
-;; overall settings of MacOS
+;;; auto-dark-eamcs.el --- Automatically set the dark-mode state of Emacs
 
-;; Set your themes here
-(set 'darktheme 'wombat)
-(set 'lightheme 'leuven)
+;; Copyright (C) 2019 Rahul M. Juliato
 
-(set 'thebeforestate "initial") 
+;; Licensed under the same terms as Emacs.
 
-(run-with-timer 0 1 (lambda ()			   
-			   ;; Get's MacOS dark mode state
-			   (if (string= (shell-command-to-string "printf %s \"$( osascript -e \'tell application \"System Events\" to tell appearance preferences to return dark mode\' )\"") "true")
-			       (progn
-				 (set 'thenowstate t)
-				 )
-			     (set 'thenowstate nil)
-			     )
+;; Author: Rahul M. Juliato
+;;      Tim Harper <timcharper at gmail dot com>
+;; Maintainer: Please send bug reports to the github site (below).
+;; Created: July 16 2019
+;; Version: 0.2
+;; Keywords: gui, os-integration
+;; URL: https://github.com/LionyxML/auto-dark-emacs
+;;
+;; This file is not part of GNU Emacs.
 
-			   ;; Verifies if Darkmode is changed since last checked
-			   (if (string= thenowstate thebeforestate)
-			       ;; If nothing is changed
-			       (progn
+;;; Commentary:
 
-				 )
-			     ;; If something is changed
+;; Auto-Dark is an auto-changer between 2 themes, dark/light, respecting the
+;; overall settings of MacOS. To enable it, install the package, add it to your load path, and:
+;;
+;;     (require 'auto-dark-emacs)
+;;
+;; To customize the themes used by light / dark mode:
+;;
+;;     M-x customize-group auto-dark-emacs
 
-			     (if (string= thenowstate "t")
-				 (progn
-				   (load-theme darktheme t)
-				   (disable-theme lightheme)
-				   )
-			       (load-theme lightheme t)
-			       (disable-theme darktheme) 
-			       )
-			     )
-			   (set 'thebeforestate thenowstate)
-			   )
-		     )
+;;; Code:
+
+(defcustom auto-dark-emacs/dark-theme 'wombat
+  "The theme to enable when dark-mode is active"
+  :group 'auto-dark-emacs)
+
+(defcustom auto-dark-emacs/light-theme 'leuven
+  "The theme to enable when dark-mode is inactive"
+  :group 'auto-dark-emacs)
+
+(defcustom auto-dark-emacs/polling-interval-seconds 5
+  "The number of seconds between which to poll for dark mode state. Emacs must be restarted for this value to take effect"
+  :group 'auto-dark-emacs
+  :type 'integer)
+
+(defcustom auto-dark-emacs/allow-osascript nil
+  "Whether to allow auto-dark-mode to shell out to osascript to check dark-mode state, if ns-do-applescript is not available"
+  :group 'auto-dark-emacs
+  :type 'boolean)
+
+(setq auto-dark-emacs/last-dark-mode-state 'unknown)
+
+(defun auto-dark-emacs/is-dark-mode-builtin ()
+  "Invoke applescript using Emacs built-in AppleScript support to see if dark mode is enabled. Returns true if it is."
+
+  (string-equal "true" (ns-do-applescript "tell application \"System Events\"
+	tell appearance preferences
+		if (dark mode) then
+			return \"true\"
+		else
+			return \"false\"
+		end if
+	end tell
+end tell")))
+
+(defun auto-dark-emacs/is-dark-mode-osascript ()
+  "Invoke applescript using Emacs using external shell command; this is less efficient, but works for non-GUI emacs"
+
+  (string-equal "true" (string-trim (shell-command-to-string "osascript -e 'tell application \"System Events\" to tell appearance preferences to return dark mode'"))))
+
+(defun auto-dark-emacs/is-dark-mode ()
+  "If supported, invoke applescript using Emacs built-in AppleScript support to see if dark mode is enabled. Otherwise, check dark-mode status using osascript, if allowed by auto-dark-emacs/allow-osascript."
+
+  (if (fboundp 'ns-do-applescript)
+      (auto-dark-emacs/is-dark-mode-builtin)
+
+    (and auto-dark-emacs/allow-osascript (auto-dark-emacs/is-dark-mode-osascript))))
+
+(defun auto-dark-emacs/check-and-set-dark-mode ()
+  "Sets the theme according to Mac OS's dark mode state. In order to prevent flickering, we only set the theme if we haven't already set the theme for the current dark mode state."
+  ;; Get's MacOS dark mode state
+  (let ((is-dark-mode (auto-dark-emacs/is-dark-mode)))
+    (if (not (eq is-dark-mode auto-dark-emacs/last-dark-mode-state))
+        (progn
+          (setq auto-dark-emacs/last-dark-mode-state is-dark-mode)
+          (if is-dark-mode
+              (progn
+                (load-theme auto-dark-emacs/dark-theme t)
+                (disable-theme auto-dark-emacs/light-theme))
+            (progn
+              (load-theme auto-dark-emacs/light-theme t)
+              (disable-theme auto-dark-emacs/dark-theme)))))))
+
+(run-with-timer 0 auto-dark-emacs/polling-interval-seconds 'auto-dark-emacs/check-and-set-dark-mode)
+
+(provide 'auto-dark-emacs)


### PR DESCRIPTION
* Use standard packaging prelude in preparation for publishing to elpa
* Define defcustom attributes to enable customization of themes and
other settings
* Use built-in applescript support over shell for better performance
* Optionally allow shell-out as a fallback, if using terminal emacs