### PR TITLE
[Feature] Support auto-dark on Linux/Gnome.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,21 @@
-## Auto-Dark for Emacs
+# Auto-Dark for Emacs
+
 [![MELPA](https://melpa.org/packages/auto-dark-badge.svg)](https://melpa.org/#/auto-dark)
 
-Do you want Emacs to follow your MacOS/Windows Dark-mode on/off options?
+Do you want Emacs to follow your MacOS/Linux/Windows Dark-mode on/off options?
 
-This is it. This program lets Emacs change between 2 user defined (customizable) themes to be automatically changed when Dark Mode set on/off on MacOS/Windows.
+This is it. This program lets Emacs change between 2 user defined (customizable) themes to be automatically changed when Dark Mode set on/off on MacOS/Linux/Windows. Now only supports Gnome on Linux.
 
-By default, themes are wombat and leuven, since these are bundled with Emacs.
+By default, themes are *wombat* and *leuven*, since these are bundled with Emacs.
 
 ## Install
+
 Install it from [MELPA](https://melpa.org/#/auto-dark) and add to your `.emacs` file:
 
 ``` emacs-lisp
 (require 'auto-dark)
 (auto-dark-mode t)
 ```
-
 
 Or simply copy the auto-dark.el file to `~/.emacs.d/auto-dark/auto-dark.el` (or clone this repository there), and then add the following to your `.emacs`:
 
@@ -33,7 +34,7 @@ Or use `use-package` to install:
 
 ## Usage
 
-Change your dark-mode settings on MacOS/Windows and let the magic happens :D
+Change your dark-mode settings on MacOS/Linux/Windows and let the magic happens :D
 
 ## Customization
 

--- a/auto-dark.el
+++ b/auto-dark.el
@@ -4,15 +4,15 @@
 ;;         Tim Harper <timcharper at gmail dot com>
 ;;         Vincent Zhang <seagle0128@gmail.com>
 ;; Created: July 16 2019
-;; Version: 0.6
-;; Keywords: macos, windows, themes, tools, unix, faces
+;; Version: 0.7
+;; Keywords: macos, windows, linux, themes, tools, faces
 ;; URL: https://github.com/LionyxML/auto-dark-emacs
 ;; Package-Requires: ((emacs "24.4"))
 ;; SPDX-License-Identifier: GPL-2.0-or-later
 
 ;;; Commentary:
 ;; Auto-Dark is an auto-changer between 2 themes, dark/light, respecting the
-;; overall settings of MacOS and Windows.
+;; overall settings of MacOS, Linux and Windows.
 ;; To enable it, install the package and add it to your load path:
 ;;
 ;;     (require 'auto-dark)
@@ -72,6 +72,10 @@ end tell")))
 this is less efficient, but works for non-GUI Emacs."
   (string-equal "true" (string-trim (shell-command-to-string "osascript -e 'tell application \"System Events\" to tell appearance preferences to return dark mode'"))))
 
+(defun auto-dark--is-dark-mode-dconf ()
+  "Invoke dconf using Emacs using external shell command."
+  (string-equal "'Yaru-dark'\n" (string-trim (shell-command-to-string "dconf read /org/gnome/desktop/interface/gtk-theme"))))
+
 (defun auto-dark--is-dark-mode-powershell ()
   "Invoke powershell using Emacs using external shell command."
   (string-equal "0" (string-trim (shell-command-to-string "powershell -noprofile -noninteractive \
@@ -96,6 +100,8 @@ HKCU:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize \
      (if (fboundp 'ns-do-applescript)
          (auto-dark--is-dark-mode-builtin)
        (and auto-dark-allow-osascript (auto-dark--is-dark-mode-osascript))))
+    ('gnu/linux
+     (auto-dark--is-dark-mode-dconf))
     ('windows-nt
      (auto-dark--is-dark-mode-powershell))))
 


### PR DESCRIPTION
Use dconf to check if dark-mode is enabled on Linux/Gnome.