### PR TITLE
Use D-Bus for Linux theme awareness

### DIFF
--- a/auto-dark.el
+++ b/auto-dark.el
@@ -118,13 +118,13 @@ In order to prevent flickering, we only set the theme if we haven't
 already set the theme for the current dark mode state."
   (let ((appearance (if (auto-dark--is-dark-mode) 'dark 'light)))
     (unless (eq appearance auto-dark--last-dark-mode-state)
-      (setq auto-dark--last-dark-mode-state appearance)
       (auto-dark--set-theme appearance))))
 
 (defun auto-dark--set-theme (appearance)
   "Set light/dark theme using emacs-plus ns-system-appearance.
 Argument APPEARANCE should be light or dark."
   (mapc #'disable-theme custom-enabled-themes)
+  (setq auto-dark--last-dark-mode-state appearance)
   (pcase appearance
     ('dark
      (disable-theme auto-dark-light-theme)

--- a/auto-dark.el
+++ b/auto-dark.el
@@ -77,11 +77,11 @@ this is less efficient, but works for non-GUI Emacs."
 (defun auto-dark--is-dark-mode-dbus ()
   "Use Emacs built-in D-Bus function to determine if dark theme is enabled."
   (eq 1 (caar (dbus-call-method
-	       :session
+               :session
                "org.freedesktop.portal.Desktop"
-	       "/org/freedesktop/portal/desktop"
-	       "org.freedesktop.portal.Settings" "Read"
-	       "org.freedesktop.appearance" "color-scheme"))))
+               "/org/freedesktop/portal/desktop"
+               "org.freedesktop.portal.Settings" "Read"
+               "org.freedesktop.appearance" "color-scheme"))))
 
 (defun auto-dark--is-dark-mode-powershell ()
   "Invoke powershell using Emacs using external shell command."
@@ -147,7 +147,8 @@ Argument APPEARANCE should be light or dark."
     (cancel-timer auto-dark--timer)))
 
 (defun auto-dark--register-dbus-listener ()
-  "Ask D-Bus to send us a signal on theme change and add a callback
+  "Register a callback function with D-Bus.
+Ask D-Bus to send us a signal on theme change and add a callback
 to change the theme."
   (setq auto-dark--dbus-listener-object
         (dbus-register-signal
@@ -158,12 +159,12 @@ to change the theme."
          "SettingChanged"
          (lambda (path var val)
            (when (and (string= path "org.freedesktop.appearance")
-		      (string= var "color-scheme"))
+                      (string= var "color-scheme"))
              (auto-dark--set-theme (pcase (car val) (0 'light) (1 'dark))))))))
 
 (defun auto-dark--unregister-dbus-listener ()
-  "Ask D-Bus to send us a signal on theme change and add a callback
-to change the theme."
+  "Unregister our callback function with D-Bus.
+Remove theme change callback registered with D-Bus."
   (dbus-unregister-object auto-dark--dbus-listener-object))
 
 (defun auto-dark--register-change-listener ()
@@ -204,8 +205,8 @@ to change the theme."
   :lighter "AD"
   (if auto-dark-mode
       (progn
-	(auto-dark--check-and-set-dark-mode)
-	(auto-dark--register-change-listener))
+        (auto-dark--check-and-set-dark-mode)
+        (auto-dark--register-change-listener))
     (auto-dark--unregister-change-listener)))
 
 (provide 'auto-dark)

--- a/auto-dark.el
+++ b/auto-dark.el
@@ -3,6 +3,7 @@
 ;; Author: Rahul M. Juliato
 ;;         Tim Harper <timcharper at gmail dot com>
 ;;         Vincent Zhang <seagle0128@gmail.com>
+;;         Jonathan Arnett <jonathan.arnett@protonmail.com>
 ;; Created: July 16 2019
 ;; Version: 0.7
 ;; Keywords: macos, windows, linux, themes, tools, faces

--- a/auto-dark.el
+++ b/auto-dark.el
@@ -54,6 +54,8 @@ to check dark-mode state, if `ns-do-applescript' is not available."
 
 (defvar auto-dark--last-dark-mode-state 'unknown)
 
+(defvar auto-dark--dbus-listener-object nil)
+
 (defun auto-dark--is-dark-mode-builtin ()
   "Invoke applescript using Emacs built-in AppleScript support.
 In order to see if dark mode is enabled.  Return true if it is."
@@ -72,9 +74,14 @@ end tell")))
 this is less efficient, but works for non-GUI Emacs."
   (string-equal "true" (string-trim (shell-command-to-string "osascript -e 'tell application \"System Events\" to tell appearance preferences to return dark mode'"))))
 
-(defun auto-dark--is-dark-mode-dconf ()
-  "Invoke dconf using Emacs using external shell command."
-  (string-equal "'Yaru-dark'\n" (string-trim (shell-command-to-string "dconf read /org/gnome/desktop/interface/gtk-theme"))))
+(defun auto-dark--is-dark-mode-dbus ()
+  "Use Emacs built-in D-Bus function to determine if dark theme is enabled."
+  (eq 1 (caar (dbus-call-method
+	       :session
+               "org.freedesktop.portal.Desktop"
+	       "/org/freedesktop/portal/desktop"
+	       "org.freedesktop.portal.Settings" "Read"
+	       "org.freedesktop.appearance" "color-scheme"))))
 
 (defun auto-dark--is-dark-mode-powershell ()
   "Invoke powershell using Emacs using external shell command."
@@ -101,29 +108,20 @@ HKCU:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize \
          (auto-dark--is-dark-mode-builtin)
        (and auto-dark-allow-osascript (auto-dark--is-dark-mode-osascript))))
     ('gnu/linux
-     (auto-dark--is-dark-mode-dconf))
+     (auto-dark--is-dark-mode-dbus))
     ('windows-nt
      (auto-dark--is-dark-mode-powershell))))
 
 (defun auto-dark--check-and-set-dark-mode ()
-  "Set the theme according to Mac OS's dark mode state.
+  "Set the theme according to the OS's dark mode state.
 In order to prevent flickering, we only set the theme if we haven't
 already set the theme for the current dark mode state."
-  (let ((is-dark-mode (auto-dark--is-dark-mode)))
-    (unless (eq is-dark-mode auto-dark--last-dark-mode-state)
-      (setq auto-dark--last-dark-mode-state is-dark-mode)
-      (mapc #'disable-theme custom-enabled-themes)
-      (if is-dark-mode
-          (progn
-            (disable-theme auto-dark-light-theme)
-            (load-theme auto-dark-dark-theme t)
-            (run-hooks 'auto-dark-dark-mode-hook))
-        (progn
-          (disable-theme auto-dark-dark-theme)
-          (load-theme auto-dark-light-theme t)
-          (run-hooks 'auto-dark-light-mode-hook))))))
+  (let ((appearance (if (auto-dark--is-dark-mode) 'dark 'light)))
+    (unless (eq appearance auto-dark--last-dark-mode-state)
+      (setq auto-dark--last-dark-mode-state appearance)
+      (auto-dark--set-theme appearance))))
 
-(defun auto-dark--ns-set-theme (appearance)
+(defun auto-dark--set-theme (appearance)
   "Set light/dark theme using emacs-plus ns-system-appearance.
 Argument APPEARANCE should be light or dark."
   (mapc #'disable-theme custom-enabled-themes)
@@ -148,6 +146,56 @@ Argument APPEARANCE should be light or dark."
   (when (timerp auto-dark--timer)
     (cancel-timer auto-dark--timer)))
 
+(defun auto-dark--register-dbus-listener ()
+  "Ask D-Bus to send us a signal on theme change and add a callback
+to change the theme."
+  (setq auto-dark--dbus-listener-object
+        (dbus-register-signal
+         :session
+         "org.freedesktop.portal.Desktop"
+         "/org/freedesktop/portal/desktop"
+         "org.freedesktop.portal.Settings"
+         "SettingChanged"
+         (lambda (path var val)
+           (when (and (string= path "org.freedesktop.appearance")
+		      (string= var "color-scheme"))
+             (auto-dark--set-theme (pcase (car val) (0 'light) (1 'dark))))))))
+
+(defun auto-dark--unregister-dbus-listener ()
+  "Ask D-Bus to send us a signal on theme change and add a callback
+to change the theme."
+  (dbus-unregister-object auto-dark--dbus-listener-object))
+
+(defun auto-dark--register-change-listener ()
+  "Register a listener to listen for the system theme to change."
+  (cond
+   ((auto-dark--use-ns-system-appearance)
+    (add-hook 'ns-system-appearance-change-functions #'auto-dark--set-theme))
+   ((auto-dark--use-dbus)
+    (auto-dark--register-dbus-listener))
+   (t (auto-dark-start-timer))))
+
+(defun auto-dark--unregister-change-listener ()
+  "Remove an existing listener for the system theme."
+  (cond
+   ((auto-dark--use-ns-system-appearance)
+    (remove-hook 'ns-system-appearance-change-functions #'auto-dark--set-theme))
+   ((auto-dark--use-dbus)
+    (auto-dark--unregister-dbus-listener))
+   (t (auto-dark-stop-timer))))
+
+(defun auto-dark--use-ns-system-appearance ()
+  "Determine whether we should use the ns-system-appearance-* functions."
+  (boundp 'ns-system-appearance-change-functions))
+
+(defun auto-dark--use-dbus ()
+  "Determine whether we should use the dbus-* functions."
+  (and (fboundp 'dbus-register-signal)
+       (fboundp 'dbus-list-activatable-names)
+       (member "org.freedesktop.portal.Desktop"
+               (dbus-list-activatable-names :session))
+       t)) ;; t only here to make this a boolean
+
 ;;;###autoload
 (define-minor-mode auto-dark-mode
   "Toggle `auto-dark-mode' on or off."
@@ -155,12 +203,10 @@ Argument APPEARANCE should be light or dark."
   :global t
   :lighter "AD"
   (if auto-dark-mode
-      (if (boundp 'ns-system-appearance-change-functions)
-          (add-hook 'ns-system-appearance-change-functions #'auto-dark--ns-set-theme)
-        (auto-dark-start-timer))
-    (if (boundp 'ns-system-appearance-change-functions)
-        (remove-hook 'ns-system-appearance-change-functions #'auto-dark--ns-set-theme)
-      (auto-dark-stop-timer))))
+      (progn
+	(auto-dark--check-and-set-dark-mode)
+	(auto-dark--register-change-listener))
+    (auto-dark--unregister-change-listener)))
 
 (provide 'auto-dark)
 


### PR DESCRIPTION
The thrust of this change is to use D-Bus' notion of "color-scheme" instead of Dconf's notion of GTK theme, as detailed in #19.

Feature changes:
- Naturally `auto-dark--is-dark-mode-dconf` has become `auto-dark--is-dark-mode-dbus`.  The new one (D-Bus) uses Emacs' built-in D-Bus integration.
- Add register and unregister functions for a D-Bus listener.  (`auto-dark--register-dbus-listener` and `auto-dark--unregister-dbus-listener`).  This necessitated the creation of the `auto-dark--dbus-listener-object` variable as a side-effect of how Emacs' D-Bus integration functions.

Other changes:
- Reduced duplication by changing `auto-dark--check-and-set-dark-mode` to call `auto-dark--set-theme` instead of duplicating the setting logic.
- Generalized the [un]registering of listeners into `auto-dark--[un]register-change-listener` functions that semi-intelligently dispatch to either `ns-*` functions for macOS or `dbus-*` functions for Linux.

I have some more ideas for cleaning up the macOS stuff, but I'll save those for another PR :grin: