### PR TITLE
Require dbus library

### DIFF
--- a/auto-dark.el
+++ b/auto-dark.el
@@ -26,6 +26,8 @@
 
 
 ;;; Code:
+(require 'dbus)
+
 (defgroup auto-dark nil
   "Automatically changes Emacs theme acording to MacOS/Windows dark-mode status."
   :group 'tools

--- a/auto-dark.el
+++ b/auto-dark.el
@@ -5,7 +5,7 @@
 ;;         Vincent Zhang <seagle0128@gmail.com>
 ;;         Jonathan Arnett <jonathan.arnett@protonmail.com>
 ;; Created: July 16 2019
-;; Version: 0.8
+;; Version: 0.9
 ;; Keywords: macos, windows, linux, themes, tools, faces
 ;; URL: https://github.com/LionyxML/auto-dark-emacs
 ;; Package-Requires: ((emacs "24.4"))


### PR DESCRIPTION
Fixes #22 

This is pretty simple fix.  I assumed that `(require 'dbus)` would fail on macOS versions of Emacs (namely [GNU Emacs For Mac OS X](https://emacsformacosx.com/), but&mdash;at least on my mac&mdash;it doesn't; it succeeds.  Please test on your own machine to verify :grin:

macOS machines won't attempt to use D-Bus, though, since the functionality is still gated by checking "activatable names":
https://github.com/LionyxML/auto-dark-emacs/blob/19040dfd1e0ad2e89a12bbdd045559711bf3193e/auto-dark.el#L197-L198