### PR TITLE
Ignore dbus errors

### DIFF
--- a/auto-dark.el
+++ b/auto-dark.el
@@ -91,12 +91,13 @@ this is less efficient, but works for non-GUI Emacs."
 
 (defun auto-dark--is-dark-mode-dbus ()
   "Use Emacs built-in D-Bus function to determine if dark theme is enabled."
-  (eq 1 (caar (dbus-call-method
-               :session
-               "org.freedesktop.portal.Desktop"
-               "/org/freedesktop/portal/desktop"
-               "org.freedesktop.portal.Settings" "Read"
-               "org.freedesktop.appearance" "color-scheme"))))
+  (eq 1 (caar (dbus-ignore-errors
+                (dbus-call-method
+                 :session
+                 "org.freedesktop.portal.Desktop"
+                 "/org/freedesktop/portal/desktop"
+                 "org.freedesktop.portal.Settings" "Read"
+                 "org.freedesktop.appearance" "color-scheme")))))
 
 (defun auto-dark--is-dark-mode-powershell ()
   "Invoke powershell using Emacs using external shell command."


### PR DESCRIPTION
In case dbus can't find the requested setting (as can happen on older gnome versions), simple ignore the error. In this case, auto-dark-mode will default to the light theme, which is an okay default.