### PR TITLE
Fix modeline lighter missing space issue

### DIFF
--- a/auto-dark.el
+++ b/auto-dark.el
@@ -229,7 +229,7 @@ Remove theme change callback registered with D-Bus."
   "Toggle `auto-dark-mode' on or off."
   :group 'auto-dark
   :global t
-  :lighter "AD"
+  :lighter " AD"
   (if auto-dark-mode
       (progn
         (unless auto-dark-detection-method


### PR DESCRIPTION
Good day @LionyxML. Lighter on modeline is not aligned properly and concatenated with the previous lighter as:
![image](https://user-images.githubusercontent.com/8293386/221423497-95c3dd89-b90e-48c1-8194-424341509216.png)

This MR is addressed to fix this issue.