### PR TITLE
Fix dbus listener light theme detection

### DIFF
--- a/auto-dark.el
+++ b/auto-dark.el
@@ -186,7 +186,7 @@ to change the theme."
          (lambda (path var val)
            (when (and (string= path "org.freedesktop.appearance")
                       (string= var "color-scheme"))
-             (auto-dark--set-theme (pcase (car val) (0 'light) (1 'dark))))))))
+             (auto-dark--set-theme (pcase (car val) (0 'light) (1 'dark) (2 'light))))))))
 
 (defun auto-dark--unregister-dbus-listener ()
   "Unregister our callback function with D-Bus.


### PR DESCRIPTION
Light theme is 2, 0 is "No preference".

https://github.com/flatpak/xdg-desktop-portal/blob/d7a304a00697d7d608821253cd013f3b97ac0fb6/data/org.freedesktop.impl.portal.Settings.xml#L33-L45