### PR TITLE
Check for window system on macOS before using AppleScript

### DIFF
--- a/auto-dark.el
+++ b/auto-dark.el
@@ -232,7 +232,8 @@ Remove theme change callback registered with D-Bus."
   "Determine which theme detection method auto-dark should use."
   (cond
    ((and (eq system-type 'darwin)
-         (fboundp 'ns-do-applescript))
+         (fboundp 'ns-do-applescript)
+	 (eq window-system 'ns))
     'applescript)
    ((and (eq system-type 'darwin)
          auto-dark-allow-osascript)


### PR DESCRIPTION
Check that window system is `ns` (GNUStep or macOS Cocoa) before using AppleScript. If `auto-dark-allow-osascript` is true, this will now work for macOS terminal.

Fixes issue #37 