### PR TITLE
README: Update doom config for version 2023-12-08

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ If you use Doom Emacs, the following config should do the trick
 
 ;; In your config.el
 
-(after! doom-themes
-  ;; set  your favorite themes
+(after! doom-ui
+  ;; set your favorite themes
   (setq! auto-dark-dark-theme 'doom-one
         auto-dark-light-theme 'doom-one-light)
   (auto-dark-mode 1))


### PR DESCRIPTION
As of today doom-themes did not work for me, with the below doom version, doom-ui does.

> doom --version
GNU Emacs     v29.1            nil
Doom core     v3.0.0-pre       HEAD, origin/master, origin/HEAD, master 03d692f12 2023-12-08 15:11:45 -0500
Doom modules  v23.12.0-pre     HEAD, origin/master, origin/HEAD, master 03d692f12 2023-12-08 15:11:45 -0500