### PR TITLE
termux: Add customize option

### DIFF
--- a/auto-dark.el
+++ b/auto-dark.el
@@ -74,7 +74,7 @@ if left as such.  Only change this value if you know what you're
 doing!"
   :group 'auto-dark
   :type 'symbol
-  :options '(applescript osascript dbus powershell winreg))
+  :options '(applescript osascript dbus powershell winreg termux))
 
 (defvar auto-dark--last-dark-mode-state 'unknown)
 


### PR DESCRIPTION
The `termux` customize option was suspiciously missing from #36.

Add it.