### PR TITLE
feat: support multiple themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Install it from [MELPA](https://melpa.org/#/auto-dark) and add to your
 
 ```emacs-lisp
 (require 'auto-dark)
-(auto-dark-mode t)
+(auto-dark-mode)
 ```
 
 
@@ -40,7 +40,7 @@ and then add the following to your `.emacs`:
 ```emacs-lisp
 (add-to-list 'load-path "~/.emacs.d/auto-dark/")
 (require 'auto-dark)
-(auto-dark-mode t)
+(auto-dark-mode)
 ```
 
 Or use `use-package` to install:
@@ -48,7 +48,7 @@ Or use `use-package` to install:
 
 ```emacs-lisp
 (use-package auto-dark
-  :config (auto-dark-mode t))
+  :init (auto-dark-mode))
 ```
 
 
@@ -61,7 +61,7 @@ If you use Spacemacs, add `(auto-dark)` to the
 
 ```emacs-lisp
 (use-package auto-dark
-  :init (spacemacs/defer-until-after-user-config (lambda () (auto-dark-mode t)))
+  :init (spacemacs/defer-until-after-user-config #'auto-dark-mode)
   :defer t)
 ```
 
@@ -83,16 +83,15 @@ enough:
 
 (after! doom-ui
   ;; set your favorite themes
-  (setq! auto-dark-dark-theme 'doom-one
-        auto-dark-light-theme 'doom-one-light)
-  (auto-dark-mode 1))
+  (setq! auto-dark-themes '((doom-one) '(doom-one-light)))
+  (auto-dark-mode))
 ```
 
 
 ## Notes for MacOS users
 
 From the box, this package takes advantage of some built-in functionality found
-on the formulaes [Emacs Plus](https://github.com/d12frosted/homebrew-emacs-plus) 
+on the formulaes [Emacs Plus](https://github.com/d12frosted/homebrew-emacs-plus)
 and [Emacs Mac](https://github.com/railwaycat/homebrew-emacsmacport?tab=readme-ov-file)
 to make detecting switches faster.
 
@@ -116,7 +115,7 @@ by going to:
 
 
 ```
-Settings -> Privacy & Security -> Emacs -> System Events 
+Settings -> Privacy & Security -> Emacs -> System Events
 ```
 
 
@@ -142,47 +141,42 @@ Following, a complete configuration with all settings set to its defaults:
 ```emacs-lisp
 (use-package auto-dark
   :ensure t
-  :config 
-  (setq auto-dark-dark-theme 'wombat)
-  (setq auto-dark-light-theme 'leuven)
-  (setq auto-dark-polling-interval-seconds 5)
-  (setq auto-dark-allow-osascript nil)
-  (setq auto-dark-allow-powershell nil)
-  ;; (setq auto-dark-detection-method nil) ;; dangerous to be set manually
-
-  (add-hook 'auto-dark-dark-mode-hook
-    (lambda ()
-      ;; something to execute when dark mode is detected))
-
-  (add-hook 'auto-dark-light-mode-hook
-    (lambda ()
-      ;; something to execute when light mode is detected))
-
-  (auto-dark-mode t))
+  :custom
+  (auto-dark-themes '((wombat) (leuven)))
+  (auto-dark-polling-interval-seconds 5)
+  (auto-dark-allow-osascript nil)
+  (auto-dark-allow-powershell nil)
+  ;; (auto-dark-detection-method nil) ;; dangerous to be set manually
+  :hook
+  (auto-dark-dark-mode
+   . (lambda ()
+        ;; something to execute when dark mode is detected
+        ))
+  (auto-dark-light-mode
+   . (lambda ()
+        ;; something to execute when light mode is detected
+        ))
+  :init (auto-dark-mode))
 ```
 
 
 A short description of each setting:
 
 
-#### `auto-dark-dark-theme`
+#### `auto-dark-themes`
 
-The theme to enable when dark-mode is active.
-
-
-Possible values are themes installed on your system found by
-`customize-themes` or `nil` to use Emacs with no themes (default
-appearance).
+A list containing two elements. The first is the list of themes to enable when
+dark-mode is active and the second is the list of themes to enable when
+dark-mode is inactive.
 
 
-#### `auto-dark-light-theme`
+Possible values for each sublist are themes installed on your system found by
+`customize-themes` or `nil` to use Emacs with no themes (default appearance).
 
-The theme to enable when dark-mode is inactive.
 
-
-Possible values are themes installed on your system found by
-`customize-themes` or `nil` to use Emacs with no themes (default
-appearance).
+If this variable is `nil`, then the set of themes from `custom-enabled-themes`
+will be used for both dark and light mode. These themes must support
+`frame-background-mode`, or else there will be no visible change.
 
 
 #### `auto-dark-polling-interval-seconds`
@@ -261,4 +255,3 @@ This package in action:
 - Linux (Gnome DE)
 
 ![auto-dark-emacs in action - linux gnome](images/demo_gnome.gif)
-

--- a/auto-dark.el
+++ b/auto-dark.el
@@ -5,7 +5,7 @@
 ;;         Vincent Zhang <seagle0128@gmail.com>
 ;;         Jonathan Arnett <jonathan.arnett@protonmail.com>
 ;; Created: July 16 2019
-;; Version: 0.12
+;; Version: 0.13
 ;; Keywords: macos, windows, linux, themes, tools, faces
 ;; URL: https://github.com/LionyxML/auto-dark-emacs
 ;; Package-Requires: ((emacs "24.4"))

--- a/auto-dark.el
+++ b/auto-dark.el
@@ -37,14 +37,19 @@
   :group 'tools
   :prefix "auto-dark-*")
 
+;; Dark & light themes need to be set together because enabling and disabling
+;; themes modifies `custom-enabled-themes', so if only one mode were expected to
+;; default to `custom-enabled-themes', it would use the wrong list of themes
+;; after the first time the other mode enables its themes.
 (defcustom auto-dark-themes nil
   "The themes to enable for dark and light modes.
-The default is to use the themes in ‘custom-enabled-themes’, but that only works
-if the theme is aware of ‘frame-background-mode’, which many don’t.
+The default is to use the themes in `custom-enabled-themes', but that only works
+if the themes are aware of `frame-background-mode', which many aren’t.
 
-In that case, you can set explicit lists of themes to switch between for dark
-and light modes. Like with ‘custom-enabled-themes’, the earlier themes in the
-list have higher precedence."
+If your themes aren’t aware of `frame-background-mode' (or you just prefer
+different themes for dark and light modes), you can set explicit lists of themes
+for each mode. Like with `custom-enabled-themes', the earlier themes in the list
+have higher precedence."
   :group 'auto-dark
   :type '(choice
           (const :tag "Use custom-enabled-themes" nil)
@@ -53,12 +58,16 @@ list have higher precedence."
                 (repeat :tag "Light" symbol))))
 
 (defcustom auto-dark-dark-theme 'wombat
-  "The theme to enable when dark-mode is active."
+  "The theme to enable when dark-mode is active.
+
+This variable is obsolete. You should set `auto-dark-themes' instead."
   :group 'auto-dark
   :type '(choice symbol (const nil)))
 
 (defcustom auto-dark-light-theme 'leuven
-  "The theme to enable when dark-mode is inactive."
+  "The theme to enable when dark-mode is inactive.
+
+This variable is obsolete. You should set `auto-dark-themes' instead."
   :group 'auto-dark
   :type '(choice symbol (const nil)))
 


### PR DESCRIPTION
Like `custom-enabled-themes`, Auto-Dark now allows multiple themes to be set for either each mode. It also now defaults to using `custom-enabled-themes` if there is nothing explicitly set for Auto-Dark.

Because (dis|en)abling themes modifies `custom-enabled-themes`, you either have to set both the dark-themes and light-themes or neither, so there is a single new variable `auto-dark-themes` that manages both lists.

If neither the new variable nor `custom-enabled-themes` is set, then it falls back to the pre-existing single theme behavior, which is now marked obsolete.

With this change[^1] I can now configure my themes like
```elisp
(use-package emacs
  :custom (custom-enabled-themes '(bringhurst solarized inheritance)))

(use-package auto-dark
  :init (auto-dark-mode))
```
(since my themes all support dark/light modes).

[^1]: This change is built on https://github.com/LionyxML/auto-dark-emacs/pull/56, because it doesn’t make sense to use `custom-enabled-themes` with Auto-Dark unless it updates `frame-background-mode`.