### PR TITLE
Improve formatting

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -3,6 +3,6 @@
 ((nil
   ;; FIXME: This is just set to silence linter line-length warnings. It should
   ;;       be set to an intentional value, then the long-lines fixed.
-  (fill-column . 167)
+  (fill-column . 136)
   (indent-tabs-mode . nil)
   (sentence-end-double-space . nil)))

--- a/auto-dark.el
+++ b/auto-dark.el
@@ -103,7 +103,8 @@ end tell")))
 
 (defun auto-dark--is-dark-mode-mac ()
   "Check if dark mode is enabled using `mac-do-applescript'."
-  (string-equal "\"true\"" (mac-do-applescript "tell application \"System Events\"
+  (string-equal "\"true\""
+                (mac-do-applescript "tell application \"System Events\"
         tell appearance preferences
                 if (dark mode) then
                         return \"true\"
@@ -117,7 +118,9 @@ end tell")))
 (defun auto-dark--is-dark-mode-osascript ()
   "Invoke applescript using Emacs using external shell command;
 this is less efficient, but works for non-GUI Emacs."
-  (string-equal "true" (string-trim (shell-command-to-string "osascript -e 'tell application \"System Events\" to tell appearance preferences to return dark mode'"))))
+  (string-equal "true"
+                (string-trim (shell-command-to-string
+                              "osascript -e 'tell application \"System Events\" to tell appearance preferences to return dark mode'"))))
 
 (defun auto-dark--is-dark-mode-dbus ()
   "Use Emacs built-in D-Bus function to determine if dark theme is enabled."
@@ -131,7 +134,9 @@ this is less efficient, but works for non-GUI Emacs."
 
 (defun auto-dark--is-dark-mode-powershell ()
   "Invoke powershell using Emacs using external shell command."
-  (string-equal "0" (string-trim (shell-command-to-string "powershell -noprofile -noninteractive \
+  (string-equal "0"
+                (string-trim (shell-command-to-string
+                              "powershell -noprofile -noninteractive \
 -nologo -ex bypass -command Get-ItemPropertyValue \
 HKCU:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize \
 -Name AppsUseLightTheme"))))
@@ -139,14 +144,18 @@ HKCU:\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize \
 (defun auto-dark--is-dark-mode-winreg ()
   "Use Emacs built-in Windows Registry function.
 In order to determine if dark theme is enabled."
-  (eq 0 (w32-read-registry 'HKCU
-			   "Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize"
-			   "AppsUseLightTheme")))
+  (eq 0
+      (w32-read-registry
+       'HKCU
+       "Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize"
+       "AppsUseLightTheme")))
 
 (defun auto-dark--is-dark-mode-termux ()
-  "Use Termux way to determine if dark theme is enabled.  ref: https://github.com/termux/termux-api/issues/425."
+  "Use Termux way to determine if dark theme is enabled.
+ref: https://github.com/termux/termux-api/issues/425."
   (string-equal "Night mode: yes"
-                (shell-command-to-string "echo -n $(cmd uimode night 2>&1 </dev/null)")))
+                (shell-command-to-string
+                 "echo -n $(cmd uimode night 2>&1 </dev/null)")))
 
 (defvar auto-dark-dark-mode-hook nil
   "List of hooks to run after dark mode is loaded." )
@@ -207,7 +216,9 @@ already set the theme for the current dark mode state."
 (defun auto-dark-start-timer ()
   "Start auto-dark timer."
   (setq auto-dark--timer
-        (run-with-timer 0 auto-dark-polling-interval-seconds #'auto-dark--check-and-set-dark-mode)))
+        (run-with-timer 0
+                        auto-dark-polling-interval-seconds
+                        #'auto-dark--check-and-set-dark-mode)))
 
 (defun auto-dark-stop-timer ()
   "Stop auto-dark timer."
@@ -228,7 +239,10 @@ to change the theme."
          (lambda (path var val)
            (when (and (string= path "org.freedesktop.appearance")
                       (string= var "color-scheme"))
-             (auto-dark--set-theme (pcase (car val) (0 'light) (1 'dark) (2 'light))))))))
+             (auto-dark--set-theme (pcase (car val)
+                                     (0 'light)
+                                     (1 'dark)
+                                     (2 'light))))))))
 
 (defun auto-dark--unregister-dbus-listener ()
   "Unregister our callback function with D-Bus.
@@ -241,7 +255,8 @@ Remove theme change callback registered with D-Bus."
    ((auto-dark--use-ns-system-appearance)
     (add-hook 'ns-system-appearance-change-functions #'auto-dark--set-theme))
    ((auto-dark--use-mac-system-appearance)
-    (add-hook 'mac-effective-appearance-change-hook #'auto-dark--check-and-set-dark-mode))
+    (add-hook 'mac-effective-appearance-change-hook
+              #'auto-dark--check-and-set-dark-mode))
    ((auto-dark--use-dbus)
     (auto-dark--register-dbus-listener))
    (t (auto-dark-start-timer))))
@@ -252,7 +267,8 @@ Remove theme change callback registered with D-Bus."
    ((auto-dark--use-ns-system-appearance)
     (remove-hook 'ns-system-appearance-change-functions #'auto-dark--set-theme))
    ((auto-dark--use-mac-system-appearance)
-    (remove-hook 'mac-effective-appearance-change-hook #'auto-dark--check-and-set-dark-mode))
+    (remove-hook 'mac-effective-appearance-change-hook
+                 #'auto-dark--check-and-set-dark-mode))
    ((auto-dark--use-dbus)
     (auto-dark--unregister-dbus-listener))
    (t (auto-dark-stop-timer))))
@@ -275,8 +291,8 @@ Remove theme change callback registered with D-Bus."
    ((and (eq system-type 'darwin)
          (or (fboundp 'ns-do-applescript)
              (fboundp 'mac-do-applescript))
-		 (or (eq window-system 'ns)
-			 (eq window-system 'mac)))
+         (or (eq window-system 'ns)
+             (eq window-system 'mac)))
     'applescript)
    ((and (eq system-type 'darwin)
          auto-dark-allow-osascript)
@@ -308,7 +324,8 @@ Remove theme change callback registered with D-Bus."
   (if auto-dark-mode
       (progn
         (unless auto-dark-detection-method
-          (setq auto-dark-detection-method (auto-dark--determine-detection-method)))
+          (setq auto-dark-detection-method
+                (auto-dark--determine-detection-method)))
         (auto-dark--check-and-set-dark-mode)
         (auto-dark--register-change-listener))
     (auto-dark--unregister-change-listener)))

--- a/auto-dark.el
+++ b/auto-dark.el
@@ -488,7 +488,8 @@ theme list."
                                      (not (equal custom-enabled-themes
                                                  (list auto-dark-light-theme))))
                                 '(() ())
-                              (list (list auto-dark-dark-theme) (list auto-dark-light-theme))))))
+                              (list (list auto-dark-dark-theme)
+                                    (list auto-dark-light-theme))))))
     ;; TODO: Once `auto-dark-dark-theme' and `auto-dark-light-theme' are
     ;;       removed, the function can be reduced to this form.
     (pcase mode
@@ -496,5 +497,4 @@ theme list."
       ('light (cadr patched-themes)))))
 
 (provide 'auto-dark)
-
 ;;; auto-dark.el ends here


### PR DESCRIPTION
Fix some incorrect indentation and try to keep lines within 80 columns.

This only affects indentation and line breaks in expressions. It doesn’t make any changes that should affect execution at all (not even introducing escaped newlines into strings to shorten the line length).

This change is purely cosmetic, but should make some overly-enthusiastic editor configurations (like mine) happier.