### PR TITLE
Add test suite and fix failing tests

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,8 @@
+;; TODO: We have to be careful what variables we set here. Some can cause the
+;;       Eldev linters to not read the settings here. See emacs-eldev/eldev#83.
+((nil
+  ;; FIXME: This is just set to silence linter line-length warnings. It should
+  ;;       be set to an intentional value, then the long-lines fixed.
+  (fill-column . 167)
+  (indent-tabs-mode . nil)
+  (sentence-end-double-space . nil)))

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+direnv_layout_dir="$PWD/.cache/direnv"
+use flake

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": ["config:base"],
+    "lockFileMaintenance": {
+        "enabled":true
+    },
+    "nix": {
+        "enabled":true
+    }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
-*.DS_Store
+*.elc
+/.cache/direnv/
+/dist
+/.eldev
+/result

--- a/Eldev
+++ b/Eldev
@@ -1,0 +1,13 @@
+;;; Eldev --- Build configuration -*- mode: emacs-lisp; lexical-binding: t; -*-
+
+(require 'eldev)
+(require 'elisp-lint)
+
+(setq
+ ;; run all linters by default
+ eldev-lint-default t
+ ;; ignore lisp files in the example directory
+ eldev-standard-excludes `(:or ,eldev-standard-excludes "./example")
+ ;; and disable the ‘elisp-lint’ validators that are already covered by
+ ;; ‘eldev-lint’ (see ‘eldev-linter-elisp’).
+ elisp-lint-ignored-validators '("checkdoc" "package-lint"))

--- a/Eldev
+++ b/Eldev
@@ -3,6 +3,23 @@
 (require 'eldev)
 (require 'elisp-lint)
 
+(define-error 'auto-dark-test-invalid-test-selection "Unknown test type")
+
+(eldev-add-loading-roots 'test "initialize")
+
+(eldev-defoption auto-dark-test-selection (type)
+  "Select tests to run; type can be `main' or `integration'"
+  :options        (-T --test-type)
+  :for-command    test
+  :value          TYPE
+  :default-value  'main
+  (pcase (intern type)
+    ('main
+     (setf eldev-test-fileset
+           `(:and ,eldev-test-fileset (:not "./tests/initialization"))))
+    ('integration (setf eldev-test-fileset "./tests/initialization"))
+    (_ (signal 'auto-dark-test-invalid-test-selection (list type)))))
+
 (setq
  ;; run all linters by default
  eldev-lint-default t

--- a/auto-dark.el
+++ b/auto-dark.el
@@ -238,6 +238,19 @@ This will load themes if necessary."
         (warn "Failed to enable theme(s): %s"
               (mapconcat #'symbol-name failures ", "))))))
 
+(defun auto-dark-toggle-appearance ()
+  "Switch between light and dark mode.
+If `auto-dark-detection-method' is nil, this will persist until the next time
+this is called. Otherwise, it could switch to the system appearance at any
+time."
+  (interactive)
+  (auto-dark--set-theme (if (eq auto-dark--last-dark-mode-state 'dark)
+                            'light
+                          ;; NB: This does _something_ even if we don’t know
+                          ;;     what the previous state was, since the user
+                          ;;     explicitly requested a change.
+                          'dark)))
+
 (defun auto-dark--set-theme (appearance)
   "Set light/dark theme Argument APPEARANCE should be light or dark."
   (setq auto-dark--last-dark-mode-state appearance)
@@ -346,7 +359,9 @@ Remove theme change callback registered with D-Bus."
    ((eq system-type 'windows-nt)
     'winreg)
    (t
-    (error "Could not determine a viable theme detection mechanism!"))))
+    (lwarn 'auto-dark :error "Could not determine a viable theme detection \
+mechanism! You can use ‘auto-dark-toggle-appearance’ to manually switch between \
+modes."))))
 
 ;;;###autoload
 (define-minor-mode auto-dark-mode

--- a/auto-dark.el
+++ b/auto-dark.el
@@ -38,26 +38,6 @@
   :group 'tools
   :prefix "auto-dark-*")
 
-;; Dark & light themes need to be set together because enabling and disabling
-;; themes modifies `custom-enabled-themes', so if only one mode were expected to
-;; default to `custom-enabled-themes', it would use the wrong list of themes
-;; after the first time the other mode enables its themes.
-(defcustom auto-dark-themes nil
-  "The themes to enable for dark and light modes.
-The default is to use the themes in `custom-enabled-themes', but that only works
-if the themes are aware of `frame-background-mode', which many aren’t.
-
-If your themes aren’t aware of `frame-background-mode' (or you just prefer
-different themes for dark and light modes), you can set explicit lists of themes
-for each mode. Like with `custom-enabled-themes', the earlier themes in the list
-have higher precedence."
-  :group 'auto-dark
-  :type '(choice
-          (const :tag "Use custom-enabled-themes" nil)
-          (list :tag "Use distinct dark & light lists"
-                (repeat :tag "Dark" symbol)
-                (repeat :tag "Light" symbol))))
-
 (defcustom auto-dark-dark-theme 'wombat
   "The theme to enable when dark-mode is active.
 
@@ -74,29 +54,6 @@ This variable is obsolete. You should set `auto-dark-themes' instead."
 
 (make-obsolete-variable 'auto-dark-dark-theme 'auto-dark-themes "0.13")
 (make-obsolete-variable 'auto-dark-light-theme 'auto-dark-themes "0.13")
-
-(defun auto-dark--patch-theme-list (themes deprecated-theme)
-  "Support the deprecated ‘auto-dark-*-theme’ variables.
-If THEMES is non-nil, it’s simply returned. If ‘custom-enabled-themes’ isn’t
-set, a list containing only DEPRECATED-THEME is returned, otherwise nil.
-
-Once the deprecated variables are removed “(auto-dark--patch-theme-list a b)”
-can be replaced by “a”."
-  (or themes
-      (unless (and custom-enabled-themes
-                   (not (equal custom-enabled-themes
-                               (list auto-dark-dark-theme)))
-                   (not (equal custom-enabled-themes
-                               (list auto-dark-light-theme))))
-        (when deprecated-theme (list deprecated-theme)))))
-
-(defun auto-dark--dark-themes ()
-  "Return the set of themes to be used in dark mode."
-  (auto-dark--patch-theme-list (car auto-dark-themes) auto-dark-dark-theme))
-
-(defun auto-dark--light-themes ()
-  "Return the set of themes to be used in light mode."
-  (auto-dark--patch-theme-list (cadr auto-dark-themes) auto-dark-light-theme))
 
 (defcustom auto-dark-polling-interval-seconds 5
   "The number of seconds between which to poll for dark mode state.
@@ -131,13 +88,13 @@ doing!"
 
 (defvar auto-dark--dbus-listener-object nil)
 
-(defun auto-dark--is-dark-mode-applescript ()
+(defun auto-dark--current-mode-applescript ()
   "Invoke AppleScript using Emacs built-in AppleScript support.
 In order to check if dark mode is enabled.  Return true if it is."
   (if (fboundp 'ns-do-applescript)
-      (auto-dark--is-dark-mode-ns)
+      (if (auto-dark--is-dark-mode-ns) 'dark 'light)
     (if (fboundp 'mac-do-applescript)
-        (auto-dark--is-dark-mode-mac)
+        (if (auto-dark--is-dark-mode-mac) 'dark 'light)
       (error "No AppleScript support available in this Emacs build.  Try setting `auto-dark-allow-osascript` to t"))))
 
 (defun auto-dark--is-dark-mode-ns ()
@@ -176,15 +133,18 @@ end tell"))))
 this is less efficient, but works for non-GUI Emacs."
   (string-equal "true" (string-trim (shell-command-to-string "osascript -e 'tell application \"System Events\" to tell appearance preferences to return dark mode'"))))
 
-(defun auto-dark--is-dark-mode-dbus ()
+(defun auto-dark--current-mode-dbus ()
   "Use Emacs built-in D-Bus function to determine if dark theme is enabled."
-  (eq 1 (caar (dbus-ignore-errors
-                (dbus-call-method
-                 :session
-                 "org.freedesktop.portal.Desktop"
-                 "/org/freedesktop/portal/desktop"
-                 "org.freedesktop.portal.Settings" "Read"
-                 "org.freedesktop.appearance" "color-scheme")))))
+  (pcase (caar (dbus-ignore-errors
+                 (dbus-call-method
+                  :session
+                  "org.freedesktop.portal.Desktop"
+                  "/org/freedesktop/portal/desktop"
+                  "org.freedesktop.portal.Settings" "Read"
+                  "org.freedesktop.appearance" "color-scheme")))
+    (0 nil)
+    (1 'dark)
+    (2 'light)))
 
 (defun auto-dark--is-dark-mode-powershell ()
   "Invoke powershell using Emacs using external shell command."
@@ -214,28 +174,39 @@ In order to determine if dark theme is enabled."
 (defvar auto-dark-light-mode-hook nil
   "List of hooks to run after light mode is loaded." )
 
-(defun auto-dark--is-dark-mode ()
-  "If dark mode is enabled."
-  (pcase auto-dark-detection-method
-    ('applescript
-     (auto-dark--is-dark-mode-applescript))
-    ('osascript
-     (auto-dark--is-dark-mode-osascript))
-    ('dbus
-     (auto-dark--is-dark-mode-dbus))
-    ('powershell
-     (auto-dark--is-dark-mode-powershell))
-    ('winreg
-     (auto-dark--is-dark-mode-winreg))
-    ('termux
-     (auto-dark--is-dark-mode-termux))))
+(defun auto-dark--current-system-mode ()
+  "Return our best guess of the mode the system is in.
+It can be dark, light, or nil."
+  (or (pcase auto-dark-detection-method
+        ('applescript
+         (auto-dark--current-mode-applescript))
+        ('osascript
+         (if (auto-dark--is-dark-mode-osascript) 'dark 'light))
+        ('dbus
+         (auto-dark--current-mode-dbus))
+        ('powershell
+         (if (auto-dark--is-dark-mode-powershell) 'dark 'light))
+        ('winreg
+         (if (auto-dark--is-dark-mode-winreg) 'dark 'light))
+        ('termux
+         (if (auto-dark--is-dark-mode-termux) 'dark 'light)))
+      (frame-parameter nil 'background-mode)
+      ;; Let Emacs guess what the background should be.
+      (frame-terminal-default-bg-mode nil)
+      ;; Give up and just use the value we last set
+      auto-dark--last-dark-mode-state
+      (lwarn 'auto-dark
+             :warning
+             "couldn’t determine current system appearance")))
 
 (defun auto-dark--check-and-set-dark-mode ()
   "Set the theme according to the OS's dark mode state.
 In order to prevent flickering, we only set the theme if we haven't
 already set the theme for the current dark mode state."
-  (let ((appearance (if (auto-dark--is-dark-mode) 'dark 'light)))
-    (unless (eq appearance auto-dark--last-dark-mode-state)
+  (let ((appearance (auto-dark--current-system-mode)))
+    (unless (and (eq appearance auto-dark--last-dark-mode-state)
+                 (equal custom-enabled-themes
+                        (auto-dark--themes-for-mode appearance)))
       (auto-dark--set-theme appearance))))
 
 (defun auto-dark--update-frame-backgrounds (appearance)
@@ -271,13 +242,10 @@ This will load themes if necessary."
   "Set light/dark theme Argument APPEARANCE should be light or dark."
   (setq auto-dark--last-dark-mode-state appearance)
   (auto-dark--update-frame-backgrounds appearance)
-  (pcase appearance
-    ('dark
-     (auto-dark--enable-themes (auto-dark--dark-themes))
-     (run-hooks 'auto-dark-dark-mode-hook))
-    ('light
-     (auto-dark--enable-themes (auto-dark--light-themes))
-     (run-hooks 'auto-dark-light-mode-hook))))
+  (auto-dark--enable-themes (auto-dark--themes-for-mode appearance))
+  (run-hooks (pcase appearance
+               ('dark 'auto-dark-dark-mode-hook)
+               ('light 'auto-dark-light-mode-hook))))
 
 (defvar auto-dark--timer nil)
 (defun auto-dark-start-timer ()
@@ -295,6 +263,8 @@ This will load themes if necessary."
 Ask D-Bus to send us a signal on theme change and add a callback
 to change the theme."
   (setq auto-dark--dbus-listener-object
+        ;; Documented at
+        ;; https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Settings.html
         (dbus-register-signal
          :session
          "org.freedesktop.portal.Desktop"
@@ -304,7 +274,10 @@ to change the theme."
          (lambda (path var val)
            (when (and (string= path "org.freedesktop.appearance")
                       (string= var "color-scheme"))
-             (auto-dark--set-theme (pcase (car val) (0 'light) (1 'dark) (2 'light))))))))
+             (pcase (car val)
+               (0 nil)
+               (1 (auto-dark--set-theme 'dark))
+               (2 (auto-dark--set-theme 'light))))))))
 
 (defun auto-dark--unregister-dbus-listener ()
   "Unregister our callback function with D-Bus.
@@ -388,6 +361,68 @@ Remove theme change callback registered with D-Bus."
         (auto-dark--check-and-set-dark-mode)
         (auto-dark--register-change-listener))
     (auto-dark--unregister-change-listener)))
+
+;; Dark & light themes need to be set together because enabling and disabling
+;; themes modifies `custom-enabled-themes', so if only one mode were expected to
+;; default to `custom-enabled-themes', it would use the wrong list of themes
+;; after the first time the other mode enables its themes.
+(defcustom auto-dark-themes nil
+  "The themes to enable for dark and light modes.
+The default is to use the themes in `custom-enabled-themes', but that only works
+if the themes are aware of `frame-background-mode', which many aren’t.
+
+If your themes aren’t aware of `frame-background-mode' (or you just prefer
+different themes for dark and light modes), you can set explicit lists of themes
+for each mode. Like with `custom-enabled-themes', the earlier themes in the list
+have higher precedence.
+
+One other thing to be aware of is that when you first load a theme, you may be
+prompted to acknowledge that the theme can run arbitrary Lisp code.
+Acknowledging this and then allowing Emacs to treat the theme as safe in future
+sessions will silence the prompt (for that particular theme). If you would just
+prefer to ignore this warning for all themes, you can set `custom-safe-themes'
+to t."
+  :group 'auto-dark
+  :type '(choice
+          (const :tag "Use custom-enabled-themes" nil)
+          (list :tag "Use distinct dark & light lists"
+                (repeat :tag "Dark" symbol)
+                (repeat :tag "Light" symbol)))
+  :set (lambda (symbol value)
+         ;; Pre-load any themes used by Auto Dark (to force prompts for
+         ;; ‘custom-safe-themes’ while the user is interacting with Auto Dark,
+         ;; rather than at initialization or ‘frame-background-mode’ charge).
+         (mapc (lambda (mode-themes)
+                 (mapc (lambda (theme)
+                         (unless (custom-theme-p theme)
+                           (load-theme theme nil t)))
+                       mode-themes))
+               value)
+         (set-default symbol value)
+         (when auto-dark-mode
+           ;; Make sure Auto Dark is showing the updated themes for the current
+           ;; ‘frame-background-mode’.
+           (auto-dark--check-and-set-dark-mode)))
+  :version "0.13")
+
+(defun auto-dark--themes-for-mode (mode)
+  "Return the set of themes to be used in MODE.
+MODE should be light or dark. If none of the Auto-Dark theme variables are set,
+this returns nil, which means that `custom-enabled-themes' will be used as the
+theme list."
+  (let ((patched-themes (or auto-dark-themes
+                            (if (and custom-enabled-themes
+                                     (not (equal custom-enabled-themes
+                                                 (list auto-dark-dark-theme)))
+                                     (not (equal custom-enabled-themes
+                                                 (list auto-dark-light-theme))))
+                                '(() ())
+                              (list (list auto-dark-dark-theme) (list auto-dark-light-theme))))))
+    ;; TODO: Once `auto-dark-dark-theme' and `auto-dark-light-theme' are
+    ;;       removed, the function can be reduced to this form.
+    (pcase mode
+      ('dark (car patched-themes))
+      ('light (cadr patched-themes)))))
 
 (provide 'auto-dark)
 

--- a/example/home.nix
+++ b/example/home.nix
@@ -1,0 +1,7 @@
+{lib, ...}: {
+  programs.emacs = {
+    enable = true;
+    extraConfig = lib.readFile ./init.el;
+    extraPackages = epkgs: [epkgs.auto-dark];
+  };
+}

--- a/example/init.el
+++ b/example/init.el
@@ -1,0 +1,23 @@
+;;; init.el --- An example configuration -*- lexical-binding: t; -*-
+
+;; We recommend customizing variables before enabling modes, to avoid
+;; “flickering” of values being set to their defaults initially, and then
+;; updated. `custom-set-variables' is very fast unless the associated package
+;; has already been loaded, in which case it may execute arbitrary code. So,
+;; doing this first ensures that you get to the rest of your initialization
+;; quickly, which can then be done in an order that matters to you.
+(custom-set-variables
+ '(auto-dark-themes '((tsdh-dark) (tsdh-light))))
+
+;; The earlier you enable modes that affect the UI, the better, as these can
+;; also cause flickering from the system defaults to the package configuration.
+;; Unfortunately, this can’t generally be done in early-init, which would
+;; otherwise allow the initial display of the frame to use the UI configuration.
+(auto-dark-mode 1)
+
+;; Non-UI initialization should go here.
+
+;; `use-package' is also a good way to configure Auto-Dark. It’s built-in on
+;; Emacs 29+, but must be installed on earlier versions.
+
+;;; init.el ends here

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,335 @@
+{
+  "nodes": {
+    "bash-strict-mode": {
+      "inputs": {
+        "flake-utils": [
+          "flaky",
+          "bash-strict-mode",
+          "flaky",
+          "flake-utils"
+        ],
+        "flaky": [
+          "flaky"
+        ],
+        "nixpkgs": [
+          "flaky",
+          "bash-strict-mode",
+          "flaky",
+          "nixpkgs"
+        ],
+        "shellcheck-nix-attributes": "shellcheck-nix-attributes"
+      },
+      "locked": {
+        "lastModified": 1722346313,
+        "narHash": "sha256-qxIzt/0BCP9LlVE1Lze/2qlM5eZ8X5hQk4E6ghiBF5w=",
+        "owner": "sellout",
+        "repo": "bash-strict-mode",
+        "rev": "098ffd0f072b3b7b3e84d9c524d18d6c62f64a47",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sellout",
+        "repo": "bash-strict-mode",
+        "type": "github"
+      }
+    },
+    "flake-schemas": {
+      "locked": {
+        "lastModified": 1701189173,
+        "narHash": "sha256-ieQZLjqfvOP+52WeMdkD/x5njEIAqjKuAc/jnmruaoc=",
+        "owner": "sellout",
+        "repo": "flake-schemas",
+        "rev": "68727227a8f349fe0831f6389d9a91064637b70c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sellout",
+        "ref": "patch-1",
+        "repo": "flake-schemas",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": [
+          "flaky",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flaky": {
+      "inputs": {
+        "bash-strict-mode": "bash-strict-mode",
+        "flake-utils": "flake-utils",
+        "garnix-systems": "garnix-systems",
+        "home-manager": "home-manager",
+        "nixpkgs": "nixpkgs",
+        "project-manager": "project-manager",
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1727247261,
+        "narHash": "sha256-J8nCKfPj04uYb11xWY1fKzlXkdXewoAIEBQRtqwCy8g=",
+        "owner": "sellout",
+        "repo": "flaky",
+        "rev": "daccb2cff4d0322b600c106b0ea9f1f9152dcd4f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sellout",
+        "repo": "flaky",
+        "type": "github"
+      }
+    },
+    "garnix-systems": {
+      "locked": {
+        "lastModified": 1723225755,
+        "narHash": "sha256-y17fVgb4LJheN4VDsHCmZRHrOJwKj8oUPvXk2FqUOnI=",
+        "owner": "garnix-io",
+        "repo": "nix-systems",
+        "rev": "c2466c5c1d3591933b4389868902e2f47a47fadb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "garnix-io",
+        "repo": "nix-systems",
+        "type": "github"
+      }
+    },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "flaky",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1720042825,
+        "narHash": "sha256-A0vrUB6x82/jvf17qPCpxaM+ulJnD8YZwH9Ci0BsAzE=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "e1391fb22e18a36f57e6999c7a9f966dc80ac073",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "release-24.05",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1724013388,
+        "narHash": "sha256-vAq+I0IWsIDq5RUc01t25iL46LLxdsmlTJ96A30bMEY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3f38e71a8e23a27569acbbfee0e83b76c86fa569",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-22_11": {
+      "locked": {
+        "lastModified": 1688392541,
+        "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-23_05": {
+      "locked": {
+        "lastModified": 1705957679,
+        "narHash": "sha256-Q8LJaVZGJ9wo33wBafvZSzapYsjOaNjP/pOnSiKVGHY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "9a333eaa80901efe01df07eade2c16d183761fa3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-23_11": {
+      "locked": {
+        "lastModified": 1720535198,
+        "narHash": "sha256-zwVvxrdIzralnSbcpghA92tWu2DV2lwv89xZc8MTrbg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "205fd4226592cc83fd4c0885a3e4c9c400efabb5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1722141560,
+        "narHash": "sha256-Ul3rIdesWaiW56PS/Ak3UlJdkwBrD4UcagCmXZR9Z7Y=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "038fb464fcfa79b4f08131b07f2d8c9a6bcc4160",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "project-manager": {
+      "inputs": {
+        "bash-strict-mode": [
+          "flaky",
+          "project-manager",
+          "flaky",
+          "bash-strict-mode"
+        ],
+        "flake-schemas": "flake-schemas",
+        "flake-utils": [
+          "flaky",
+          "project-manager",
+          "flaky",
+          "flake-utils"
+        ],
+        "flaky": [
+          "flaky"
+        ],
+        "nixpkgs": [
+          "flaky",
+          "project-manager",
+          "flaky",
+          "nixpkgs"
+        ],
+        "nixpkgs-22_11": "nixpkgs-22_11",
+        "nixpkgs-23_05": "nixpkgs-23_05",
+        "nixpkgs-23_11": "nixpkgs-23_11",
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1723360458,
+        "narHash": "sha256-l+junhIWTsYvVVFp/0YYfFPmTxODWJ2IoHesIvly4FQ=",
+        "owner": "sellout",
+        "repo": "project-manager",
+        "rev": "342359f930e23ff26a6ccdace93089f4a7fff00c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sellout",
+        "repo": "project-manager",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "bash-strict-mode": [
+          "flaky",
+          "bash-strict-mode"
+        ],
+        "flake-utils": [
+          "flaky",
+          "flake-utils"
+        ],
+        "flaky": "flaky",
+        "nixpkgs": [
+          "flaky",
+          "nixpkgs"
+        ],
+        "systems": [
+          "flaky",
+          "systems"
+        ]
+      }
+    },
+    "shellcheck-nix-attributes": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1586929030,
+        "narHash": "sha256-a0WyWaz+nMYFWI43Ip9EUnPuBW0O4EIiTzYZKGqNjss=",
+        "owner": "Fuuzetsu",
+        "repo": "shellcheck-nix-attributes",
+        "rev": "51b49d5fe65ece69eb5e2003396bf096083ec281",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Fuuzetsu",
+        "repo": "shellcheck-nix-attributes",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1726558681,
+        "narHash": "sha256-vta8mxLa5XxpHfb9HCiavFqBrX2xJDvZiKHZOy4kvlA=",
+        "owner": "sellout",
+        "repo": "nix-systems",
+        "rev": "aa9520a9a0f92098d3576c3b4eafcb32c13d6800",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sellout",
+        "repo": "nix-systems",
+        "type": "github"
+      }
+    },
+    "treefmt-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "flaky",
+          "project-manager",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1722330636,
+        "narHash": "sha256-uru7JzOa33YlSRwf9sfXpJG+UAV+bnBEYMjrzKrQZFw=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "768acdb06968e53aa1ee8de207fd955335c754b7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,117 @@
+{
+  description = "Automatically sets the dark-mode theme based on macOS/Linux/Windows status";
+
+  nixConfig = {
+    ## https://github.com/NixOS/rfcs/blob/master/rfcs/0045-deprecate-url-syntax.md
+    extra-experimental-features = ["no-url-literals"];
+    extra-substituters = ["https://cache.garnix.io"];
+    extra-trusted-public-keys = [
+      "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="
+    ];
+    ## Isolate the build.
+    sandbox = "relaxed";
+    use-registries = false;
+  };
+
+  outputs = {
+    bash-strict-mode,
+    flake-utils,
+    flaky,
+    nixpkgs,
+    self,
+    systems,
+  }: let
+    pname = "auto-dark";
+
+    supportedSystems = import systems;
+  in
+    {
+      schemas = {
+        inherit
+          (flaky.schemas)
+          overlays
+          homeConfigurations
+          packages
+          devShells
+          checks
+          formatter
+          ;
+      };
+
+      overlays = {
+        default = flaky.lib.elisp.overlays.default self.overlays.emacs;
+
+        emacs = final: prev: efinal: eprev: {inherit (self.packages.${final.system}) auto-dark;};
+      };
+
+      homeConfigurations =
+        builtins.listToAttrs
+        (builtins.map
+          (flaky.lib.homeConfigurations.example self [./example/home.nix])
+          supportedSystems);
+    }
+    // flake-utils.lib.eachSystem supportedSystems (system: let
+      pkgs = nixpkgs.legacyPackages.${system}.appendOverlays [
+        flaky.overlays.dependencies
+        flaky.overlays.elisp-dependencies
+      ];
+
+      src = pkgs.lib.cleanSource ./.;
+    in {
+      packages =
+        {
+          default = self.packages.${system}.auto-dark;
+          auto-dark = pkgs.callPackage ./nix/packages/auto-dark.nix {
+            inherit src;
+            inherit (pkgs) emacsPackages;
+            checkedDrv = bash-strict-mode.lib.checkedDrv pkgs;
+          };
+        }
+        // nixpkgs.lib.listToAttrs (nixpkgs.lib.concatMap (v:
+          if nixpkgs.lib.elem system pkgs.${v}.meta.platforms
+          then [
+            {
+              name = "${v}_auto-dark";
+              value = pkgs.callPackage ./nix/packages/auto-dark.nix {
+                inherit src;
+                checkedDrv = bash-strict-mode.lib.checkedDrv pkgs;
+                emacsPackages = pkgs.emacsPackagesFor pkgs.${v};
+              };
+            }
+          ]
+          else []) [
+          ## Emacs 28 doesn’t like setting up frames in batch mode, so only test
+          ## on Emacs 29 for now.
+          "emacs29"
+          "emacs29-gtk3"
+          "emacs29-macport"
+          "emacs29-nox"
+          "emacs29-pgtk"
+        ]);
+
+      devShells.default = bash-strict-mode.lib.checkedDrv pkgs (pkgs.mkShell {
+        inherit (pkgs) system;
+        inputsFrom =
+          builtins.attrValues self.checks.${system}
+          ++ builtins.attrValues self.packages.${system};
+      });
+
+      checks = import ./nix/checks.nix {
+        inherit src;
+        inherit (pkgs) emacsPackages emacsWithPackages stdenv;
+        checkedDrv = bash-strict-mode.lib.checkedDrv pkgs;
+      };
+
+      formatter = pkgs.alejandra;
+    });
+
+  inputs = {
+    ## Flaky should generally be the source of truth for its inputs.
+    flaky.url = "github:sellout/flaky";
+
+    bash-strict-mode.follows = "flaky/bash-strict-mode";
+    flake-utils.follows = "flaky/flake-utils";
+    nixpkgs.follows = "flaky/nixpkgs";
+    systems.follows = "flaky/systems";
+  };
+}

--- a/garnix.yaml
+++ b/garnix.yaml
@@ -1,0 +1,13 @@
+{
+    "builds": {
+        "exclude": [
+            "*.x86_64-darwin",
+            "*.x86_64-darwin.*",
+            "homeConfigurations.x86_64-darwin-example"
+        ],
+        "include": [
+            "*.*",
+            "*.*.*"
+        ]
+    }
+}

--- a/initialize/auto-dark-initialize.el
+++ b/initialize/auto-dark-initialize.el
@@ -1,0 +1,60 @@
+;;; auto-dark-initialize.el --- Functions to simulate Emacs’ initialization  -*- lexical-binding: t; -*-
+
+;; Author: Greg Pfeil <greg@technomadic.org>
+;; Created: October 11 2024
+;; Version: 0.1.0
+;; Keywords: maint, tools
+;; URL: https://github.com/LionyxML/auto-dark-emacs
+;; SPDX-License-Identifier: AGPL-3.0-or-later
+
+;;; Commentary:
+
+;; This library attempts to simulate the Emacs initialization process, for
+;; writing tests that are sensitive to initialization.
+
+;;; Code:
+
+(defvar auto-dark-initialize--current-state nil
+  "The phase of initialization we’ve gotten to.
+So users don’t have to call every function.")
+
+(defun auto-dark-initialize-start ()
+  "Set up various things to a state similar to what existed before early init."
+  (if auto-dark-initialize--current-state
+      (lwarn 'auto-dark-initialize :warn
+             "Initialization is already at least as far as 'start, not running.")
+    (setq after-init-time nil
+          auto-dark-initialize--current-state 'start)))
+
+(defun auto-dark-initialize-after-early-init (autoload-features)
+  "Update state as done between early init and the rest of the init files.
+E.g., initializing the package system and setting up the display.
+AUTOLOAD-FEATURES should be a list of symbols naming the autoload features for
+packages you are testing."
+  (unless auto-dark-initialize--current-state
+    (auto-dark-initialize-start))
+  (if (eq auto-dark-initialize--current-state 'start)
+      (progn
+        (mapc (lambda (feature) (require feature)) autoload-features)
+        (custom-set-variables
+         '(frame-background-mode 'light))
+        (setq auto-dark-initialize--current-state 'early-init))
+    (lwarn 'auto-dark-initialize :warn
+           "Initialization is already at least as far as 'early-init, not running.")))
+
+(defun auto-dark-initialize-finish ()
+  "This is the rest of the init process after the various files are loaded.
+After this is run, the tests should reflect a “normal” Emacs session."
+  (pcase auto-dark-initialize--current-state
+    ('(nil start)
+     (signal 'auto-dark-initialize
+             '("At least ‘auto-dark-initialize-after-early-init needs to be called first.’")))
+    ('early-init
+     (setq after-init-time (current-time))
+     (run-hooks 'after-init-hook)
+     (setq auto-dark-initialize--current-state 'finished))
+    (_ (lwarn 'auto-dark-initialize :warn
+              "Initialization has already finished, not running."))))
+
+(provide 'auto-dark-initialize)
+;;; auto-dark-initialize.el ends here

--- a/nix/checks.nix
+++ b/nix/checks.nix
@@ -1,0 +1,81 @@
+{
+  checkedDrv,
+  emacsPackages,
+  emacsWithPackages,
+  src,
+  stdenv,
+}: let
+  lib = import ./lib.nix {inherit emacsPackages;};
+in {
+  doctor = checkedDrv (stdenv.mkDerivation {
+    inherit src;
+    inherit (lib) ELDEV_LOCAL;
+
+    name = "eldev doctor";
+
+    nativeBuildInputs = [
+      (emacsWithPackages (e: [e.elisp-lint]))
+      # Emacs-lisp build tool, https://doublep.github.io/eldev/
+      emacsPackages.eldev
+    ];
+
+    buildPhase = ''
+      runHook preBuild
+      ## TODO: Currently needed to make a temp file in
+      ##      `eldev--create-internal-pseudoarchive-descriptor`.
+      HOME="$(mktemp --directory --tmpdir fake-home.XXXXXX)"
+      mkdir -p "$HOME/.cache/eldev"
+      ## NB: `EMACSNATIVELOADPATH` is needed by `elisp-lin
+      EMACSNATIVELOADPATH= eldev doctor
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p "$out"
+      runHook postInstall
+    '';
+  });
+
+  lint = let
+    emacs = emacsWithPackages (e: [
+      e.elisp-lint
+      e.package-lint
+      e.relint
+    ]);
+  in
+    checkedDrv (stdenv.mkDerivation {
+      inherit src;
+      inherit (lib) ELDEV_LOCAL;
+
+      name = "eldev lint";
+
+      nativeBuildInputs = [
+        emacs
+        emacsPackages.eldev
+      ];
+
+      postPatch = lib.setUpLocalDependencies emacs.deps;
+
+      buildPhase = ''
+        runHook preBuild
+
+        ## Need `--external` here so that we don’t try to download any
+        ## package archives (which would break the sandbox).
+        ## NB: `EMACSNATIVELOADPATH` is needed by `elisp-lint`.
+        ## TODO: Currently need `HOME` to make a temp file in
+        ##      `eldev--create-internal-pseudoarchive-descriptor`.
+        EMACSNATIVELOADPATH= \
+          HOME="$(mktemp --directory --tmpdir fake-home.XXXXXX)" \
+          eldev --external lint --required
+
+        runHook postBuild
+      '';
+
+      installPhase = ''
+        runHook preInstall
+        mkdir -p "$out"
+        runHook preInstall
+      '';
+    });
+}

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -1,0 +1,21 @@
+{emacsPackages}: let
+  emacsPath = package: "${package}/share/emacs/site-lisp/elpa/${package.pname}-${package.version}";
+in {
+  ## We need to tell Eldev where to find its Emacs package.
+  ELDEV_LOCAL = emacsPath emacsPackages.eldev;
+
+  ## Ideally this could just
+  ##     (setq eldev-external-package-dir "${deps}/share/emacs/site-lisp/elpa")
+  ## but Eldev wants to write to that directory, even if there's nothing to
+  ## download.
+  setUpLocalDependencies = deps: ''
+    {
+      echo
+      echo "(mapcar 'eldev-use-local-dependency"
+      echo "        (directory-files"
+      echo "         \"${deps}/share/emacs/site-lisp/elpa\""
+      echo "         t"
+      echo "         directory-files-no-dot-files-regexp))"
+    } >> Eldev
+  '';
+}

--- a/nix/packages/auto-dark.nix
+++ b/nix/packages/auto-dark.nix
@@ -1,0 +1,69 @@
+{
+  checkedDrv,
+  emacsPackages,
+  src,
+}: let
+  lib = import ../lib.nix {inherit emacsPackages;};
+
+  ## Read version in format: ;; Version: x.y(.z)?
+  readVersion = fp:
+    builtins.elemAt
+    (builtins.match
+      ".*(;; Version: ([[:digit:]]+\.[[:digit:]]+(\.[[:digit:]]+)?)).*"
+      (builtins.readFile fp))
+    1;
+
+  emacsWithPackages = emacsPackages.emacsWithPackages (epkgs: [
+    epkgs.buttercup
+    epkgs.elisp-lint
+    epkgs.use-package # TODO: Conditionalize on Emacs <29?
+  ]);
+in
+  checkedDrv (emacsPackages.trivialBuild {
+    inherit src;
+    inherit (lib) ELDEV_LOCAL;
+
+    pname = "auto-dark";
+
+    version = readVersion ../../auto-dark.el;
+
+    nativeBuildInputs = [
+      emacsWithPackages
+      # Emacs-lisp build tool, https://doublep.github.io/eldev/
+      emacsPackages.eldev
+    ];
+
+    postPatch = lib.setUpLocalDependencies emacsWithPackages.deps;
+
+    doCheck = true;
+
+    checkPhase = ''
+      runHook preCheck
+
+      ## TODO: Currently needed to make a temp file in
+      ##      `eldev--create-internal-pseudoarchive-descriptor`.
+      HOME="$(mktemp --directory --tmpdir fake-home.XXXXXX)"
+
+      ## Need `--external` here so that we don’t try to download any
+      ## package archives (which would break the sandbox).
+      eldev --external test
+
+      runHook postCheck
+    '';
+
+    doInstallCheck = true;
+
+    installCheckPhase = ''
+      runHook preInstallCheck
+
+      ## TODO: Currently needed to make a temp file in
+      ##      `eldev--create-internal-pseudoarchive-descriptor`.
+      HOME="$(mktemp --directory --tmpdir fake-home.XXXXXX)"
+
+      ## Need `--external` here so that we don’t try to download any
+      ## package archives (which would break the sandbox).
+      eldev --external --packaged test
+
+      runHook postInstallCheck
+    '';
+  })

--- a/tests/basic.el
+++ b/tests/basic.el
@@ -1,0 +1,52 @@
+;;; basic.el --- Tests that work in any environment -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;;; Code:
+
+(require 'auto-dark)
+(require 'buttercup)
+
+;; Track whether `auto-dark-mode' was enabled before we started the tests.
+(defvar auto-dark-tests--original-state auto-dark-mode)
+(defvar auto-dark-tests--original-enabled-themes custom-enabled-themes)
+
+(custom-set-variables
+ ;; TODO: This is not a valid value, but it stops Auto-Dark from trying to set
+ ;;       the detection method. See #73.
+ '(auto-dark-detection-method 'manual)
+ '(custom-enabled-themes ())
+ '(frame-background-mode 'light))
+
+;; Ensure `auto-dark-mode' is disabled for this part of the test.
+(when auto-dark-tests--original-state
+  (auto-dark-mode -1))
+
+(describe "when disabled"
+  (it "shouldn’t affect enabled themes"
+    (expect custom-enabled-themes :to-be nil)
+    (custom-set-variables
+     '(auto-dark-themes '((tango-dark) (tango))))
+    (expect auto-dark-themes :to-equal '((tango-dark) (tango)))
+    (expect custom-enabled-themes :to-be nil)))
+
+(describe "when enabled"
+  (it "should immediately update themes"
+    (expect auto-dark-themes :to-equal '((tango-dark) (tango)))
+    (auto-dark-mode 1)
+    (expect auto-dark-themes :to-equal '((tango-dark) (tango)))
+    (expect custom-enabled-themes :to-equal '(tango)))
+  (it "should reflect changes to themes immediately"
+    (custom-set-variables
+     '(auto-dark-themes '((wombat) (leuven))))
+    (expect auto-dark-themes :to-equal '((wombat) (leuven)))
+    (expect custom-enabled-themes :to-equal '(leuven))))
+
+;; Restore the original state
+(unless auto-dark-tests--original-state
+  (auto-dark-mode -1))
+
+(custom-set-variables
+ '(custom-enabled-themes auto-dark-tests--original-enabled-themes))
+
+;;; basic.el ends here

--- a/tests/basic.el
+++ b/tests/basic.el
@@ -42,6 +42,16 @@
     (expect auto-dark-themes :to-equal '((wombat) (leuven)))
     (expect custom-enabled-themes :to-equal '(leuven))))
 
+(describe "toggling"
+  (before-each
+    (auto-dark-toggle-appearance))
+  (it "should invert the current appearance"
+    (expect custom-enabled-themes :to-equal '(wombat)))
+  (it "should invert the current appearance again"
+    (expect custom-enabled-themes :to-equal '(leuven)))
+  (it "should invert the current appearance and again"
+    (expect custom-enabled-themes :to-equal '(wombat))))
+
 ;; Restore the original state
 (unless auto-dark-tests--original-state
   (auto-dark-mode -1))

--- a/tests/initialization/README.md
+++ b/tests/initialization/README.md
@@ -1,0 +1,5 @@
+# initialization tests
+
+These files test that the package behaves in various contexts when first loaded.
+
+They each need to be run in their own instance, to ensure they don’t interfere with each other.

--- a/tests/initialization/customize-first.el
+++ b/tests/initialization/customize-first.el
@@ -38,8 +38,10 @@
       (expect (boundp 'auto-dark-detection-method) :to-be-truthy)
       (expect auto-dark-polling-interval-seconds :to-be 5)
       (expect auto-dark-themes :to-equal '((tsdh-dark) (tsdh-light)))
-      (expect auto-dark-dark-theme :to-be 'wombat)
-      (expect auto-dark-light-theme :to-be 'leuven)))
+      ;; These two are handled specially – they aren’t set to their defaults
+      ;; until after initialization.
+      (expect (boundp 'auto-dark-dark-theme) :to-be nil)
+      (expect (boundp 'auto-dark-light-theme) :to-be nil)))
 
   (describe "after init"
     (before-all

--- a/tests/initialization/customize-first.el
+++ b/tests/initialization/customize-first.el
@@ -1,0 +1,58 @@
+;;; customize-first.el --- Customize vars before enabling -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; Tests the recommended flow of customizing variables before enabling
+;; Auto-Dark.
+
+;;; Code:
+
+(require 'auto-dark-initialize)
+(require 'buttercup)
+
+(describe "package initialization with variables pre-set"
+  (before-all
+    (auto-dark-initialize-after-early-init '(auto-dark-autoloads))
+    (custom-set-variables
+     '(auto-dark-themes '((tsdh-dark) (tsdh-light)))))
+  (describe "before enabling"
+    (it "should not have enabled the themes yet"
+      (expect custom-enabled-themes :to-be ()))
+    (it "should not have bound Auto-Dark variables"
+      (expect (boundp 'auto-dark-allow-osascript) :to-be nil)
+      (expect (boundp 'auto-dark-allow-powershell) :to-be nil)
+      (expect (boundp 'auto-dark-dark-theme) :to-be nil)
+      (expect (boundp 'auto-dark-detection-method) :to-be nil)
+      (expect (boundp 'auto-dark-light-theme) :to-be nil)
+      (expect (boundp 'auto-dark-polling-interval-seconds) :to-be nil)
+      (expect (boundp 'auto-dark-themes) :to-be nil)))
+
+  (describe "after enabling"
+    (before-all
+      (auto-dark-mode 1))
+    (it "themes should be enabled"
+      (expect custom-enabled-themes :to-be-in '((tsdh-dark) (tsdh-light))))
+    (it "should have bound Auto-Dark variables"
+      (expect auto-dark-allow-osascript :to-be nil)
+      (expect auto-dark-allow-powershell :to-be nil)
+      (expect (boundp 'auto-dark-detection-method) :to-be-truthy)
+      (expect auto-dark-polling-interval-seconds :to-be 5)
+      (expect auto-dark-themes :to-equal '((tsdh-dark) (tsdh-light)))
+      (expect auto-dark-dark-theme :to-be 'wombat)
+      (expect auto-dark-light-theme :to-be 'leuven)))
+
+  (describe "after init"
+    (before-all
+      (auto-dark-initialize-finish))
+    (it "themes should be enabled"
+      (expect custom-enabled-themes :to-be-in '((tsdh-dark) (tsdh-light))))
+    (it "Old Auto-Dark variables should now be set"
+      (expect auto-dark-allow-osascript :to-be nil)
+      (expect auto-dark-allow-powershell :to-be nil)
+      (expect (boundp 'auto-dark-detection-method) :to-be-truthy)
+      (expect auto-dark-polling-interval-seconds :to-be 5)
+      (expect auto-dark-themes :to-equal '((tsdh-dark) (tsdh-light)))
+      (expect auto-dark-dark-theme :to-be 'wombat)
+      (expect auto-dark-light-theme :to-be 'leuven))))
+
+;;; customize-first.el ends here

--- a/tests/initialization/de-facto-old.el
+++ b/tests/initialization/de-facto-old.el
@@ -1,0 +1,71 @@
+;;; de-facto-old.el --- Tests that need to be run in a fresh instance -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; This models the most common initialization style of Emacs, where Customize
+;; inserts a `custom-set-variables' form at the end of `user-init-file'.
+
+;; 1. `package-initialize' is called, then
+;; 2. `user-init-file' is loaded, which has
+;;   a. some initialization of `auto-dark-mode' and
+;;   b. `custom-set-variables' at the end.
+
+;;; Code:
+
+(require 'auto-dark-initialize)
+(require 'buttercup)
+
+;; To silence “reference to free variable” warnings
+(defvar auto-dark-allow-osascript)
+(defvar auto-dark-allow-powershell)
+(defvar auto-dark-dark-theme)
+(defvar auto-dark-light-theme)
+(defvar auto-dark-polling-interval-seconds)
+(defvar auto-dark-themes)
+
+(describe "Emacs’s de-facto initialization with old theme vars"
+  (before-all
+    (auto-dark-initialize-after-early-init '(auto-dark-autoloads)))
+
+  (describe "after ‘package-initialize’ is called"
+    (it "should not have enabled the themes yet"
+      (expect custom-enabled-themes :to-be ()))
+    (it "should not have bound Auto-Dark variables"
+      (expect (boundp 'auto-dark-allow-osascript) :to-be nil)
+      (expect (boundp 'auto-dark-allow-powershell) :to-be nil)
+      (expect (boundp 'auto-dark-dark-theme) :to-be nil)
+      (expect (boundp 'auto-dark-detection-method) :to-be nil)
+      (expect (boundp 'auto-dark-light-theme) :to-be nil)
+      (expect (boundp 'auto-dark-polling-interval-seconds) :to-be nil)
+      (expect (boundp 'auto-dark-themes) :to-be nil)))
+
+  (describe "before ‘custom-set-variables’ is called"
+    (before-all
+      (auto-dark-mode 1))
+
+    (it "should not have enabled the themes yet"
+      (expect custom-enabled-themes :to-equal ()))
+    (it "should have bound Auto-Dark variables to their standard values"
+      (expect auto-dark-allow-osascript :to-be nil)
+      (expect auto-dark-allow-powershell :to-be nil)
+      (expect (boundp 'auto-dark-detection-method) :to-be-truthy)
+      (expect auto-dark-polling-interval-seconds :to-be 5)
+      (expect auto-dark-themes :to-be nil)
+      (expect auto-dark-dark-theme :to-be nil)
+      (expect auto-dark-light-theme :to-be nil)))
+
+  (describe "after vars are set"
+    (before-all
+      (custom-set-variables
+       '(auto-dark-dark-theme 'tsdh-dark)
+       '(auto-dark-light-theme 'tsdh-light)))
+
+    (it "should have configured Auto-Dark"
+      (expect auto-dark-themes :to-be nil)
+      ;; And _now_ these have their standard values.
+      (expect auto-dark-dark-theme :to-be 'tsdh-dark)
+      (expect auto-dark-light-theme :to-be 'tsdh-light))
+    (it "should have enabled the correct themes"
+      (expect custom-enabled-themes :to-be-in '((tsdh-dark) (tsdh-light))))))
+
+;;; de-facto-old.el ends here

--- a/tests/initialization/de-facto-old.el
+++ b/tests/initialization/de-facto-old.el
@@ -51,8 +51,10 @@
       (expect (boundp 'auto-dark-detection-method) :to-be-truthy)
       (expect auto-dark-polling-interval-seconds :to-be 5)
       (expect auto-dark-themes :to-be nil)
-      (expect auto-dark-dark-theme :to-be nil)
-      (expect auto-dark-light-theme :to-be nil)))
+      ;; These two are handled specially – they aren’t set to their defaults
+      ;; until after initialization.
+      (expect (boundp 'auto-dark-dark-theme) :to-be nil)
+      (expect (boundp 'auto-dark-light-theme) :to-be nil)))
 
   (describe "after vars are set"
     (before-all
@@ -60,11 +62,22 @@
        '(auto-dark-dark-theme 'tsdh-dark)
        '(auto-dark-light-theme 'tsdh-light)))
 
+    ;; NB: When using the old variables, they won’t be set until
+    ;;    `after-init-hook' is run.
+    (it "shouldn’t have changed anything yet"
+      (expect (boundp 'auto-dark-dark-theme) :to-be nil)
+      (expect (boundp 'auto-dark-light-theme) :to-be nil)))
+
+  (describe "after ‘user-init-file’ is loaded"
+    (before-all
+      (auto-dark-initialize-finish))
+
     (it "should have configured Auto-Dark"
       (expect auto-dark-themes :to-be nil)
       ;; And _now_ these have their standard values.
       (expect auto-dark-dark-theme :to-be 'tsdh-dark)
       (expect auto-dark-light-theme :to-be 'tsdh-light))
+
     (it "should have enabled the correct themes"
       (expect custom-enabled-themes :to-be-in '((tsdh-dark) (tsdh-light))))))
 

--- a/tests/initialization/de-facto.el
+++ b/tests/initialization/de-facto.el
@@ -52,8 +52,10 @@
       (expect (boundp 'auto-dark-detection-method) :to-be-truthy)
       (expect auto-dark-polling-interval-seconds :to-be 5)
       (expect auto-dark-themes :to-be nil)
-      (expect auto-dark-dark-theme :to-be 'wombat)
-      (expect auto-dark-light-theme :to-be 'leuven)))
+      ;; These two are handled specially – they aren’t set to their defaults
+      ;; until after initialization.
+      (expect (boundp 'auto-dark-dark-theme) :to-be nil)
+      (expect (boundp 'auto-dark-light-theme) :to-be nil)))
 
   (describe "after variables are set"
     (before-all
@@ -62,8 +64,9 @@
 
     (it "should have configured Auto-Dark"
       (expect auto-dark-themes :to-equal '((tsdh-dark) (tsdh-light)))
-      (expect auto-dark-dark-theme :to-be 'wombat)
-      (expect auto-dark-light-theme :to-be 'leuven))
+      ;; And these are still unbound.
+      (expect (boundp 'auto-dark-dark-theme) :to-be nil)
+      (expect (boundp 'auto-dark-light-theme) :to-be nil))
 
     (it "should have enabled the correct themes"
       (expect custom-enabled-themes :to-be-in '((tsdh-dark) (tsdh-light))))))

--- a/tests/initialization/de-facto.el
+++ b/tests/initialization/de-facto.el
@@ -1,0 +1,71 @@
+;;; de-facto.el --- Tests that need to be run in a fresh instance -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; This models the most common initialization style of Emacs, where Customize
+;; inserts a `custom-set-variables' form at the end of `user-init-file'.
+
+;; 1. `package-initialize' is called, then
+;; 2. `user-init-file' is loaded, which has
+;;   a. some initialization of `auto-dark-mode' and
+;;   b. `custom-set-variables' at the end.
+
+;;; Code:
+
+(require 'auto-dark-initialize)
+(require 'buttercup)
+
+;; To silence “reference to free variable” warnings
+(defvar auto-dark-allow-osascript)
+(defvar auto-dark-allow-powershell)
+(defvar auto-dark-dark-theme)
+(defvar auto-dark-detection-method)
+(defvar auto-dark-light-theme)
+(defvar auto-dark-polling-interval-seconds)
+(defvar auto-dark-themes)
+
+(describe "Emacs’s de-facto initialization"
+  (before-all
+    (auto-dark-initialize-after-early-init '(auto-dark-autoloads)))
+
+  (describe "after ‘package-initialize’ is called"
+    (it "should not have enabled the themes yet"
+      (expect custom-enabled-themes :to-be ()))
+    (it "should not have bound Auto-Dark variables"
+      (expect (boundp 'auto-dark-allow-osascript) :to-be nil)
+      (expect (boundp 'auto-dark-allow-powershell) :to-be nil)
+      (expect (boundp 'auto-dark-dark-theme) :to-be nil)
+      (expect (boundp 'auto-dark-detection-method) :to-be nil)
+      (expect (boundp 'auto-dark-light-theme) :to-be nil)
+      (expect (boundp 'auto-dark-polling-interval-seconds) :to-be nil)
+      (expect (boundp 'auto-dark-themes) :to-be nil)))
+
+  (describe "before ‘custom-set-variables’ is called"
+    (before-all
+      (auto-dark-mode 1))
+
+    (it "should not have enabled the themes yet"
+      (expect custom-enabled-themes :to-equal ()))
+    (it "should have bound Auto-Dark variables to their standard values"
+      (expect auto-dark-allow-osascript :to-be nil)
+      (expect auto-dark-allow-powershell :to-be nil)
+      (expect (boundp 'auto-dark-detection-method) :to-be-truthy)
+      (expect auto-dark-polling-interval-seconds :to-be 5)
+      (expect auto-dark-themes :to-be nil)
+      (expect auto-dark-dark-theme :to-be 'wombat)
+      (expect auto-dark-light-theme :to-be 'leuven)))
+
+  (describe "after variables are set"
+    (before-all
+      (custom-set-variables
+       '(auto-dark-themes '((tsdh-dark) (tsdh-light)))))
+
+    (it "should have configured Auto-Dark"
+      (expect auto-dark-themes :to-equal '((tsdh-dark) (tsdh-light)))
+      (expect auto-dark-dark-theme :to-be 'wombat)
+      (expect auto-dark-light-theme :to-be 'leuven))
+
+    (it "should have enabled the correct themes"
+      (expect custom-enabled-themes :to-be-in '((tsdh-dark) (tsdh-light))))))
+
+;;; de-facto.el ends here

--- a/tests/initialization/defaults.el
+++ b/tests/initialization/defaults.el
@@ -52,8 +52,10 @@
       (expect (boundp 'auto-dark-detection-method) :to-be-truthy)
       (expect auto-dark-polling-interval-seconds :to-be 5)
       (expect auto-dark-themes :to-be nil)
-      (expect auto-dark-dark-theme :to-be 'wombat)
-      (expect auto-dark-light-theme :to-be 'leuven)))
+      ;; These two are handled specially – they aren’t set to their defaults
+      ;; until after initialization.
+      (expect (boundp 'auto-dark-dark-theme) :to-be nil)
+      (expect (boundp 'auto-dark-light-theme) :to-be nil)))
 
   (describe "after ‘user-init-file’ is loaded"
     (before-all
@@ -61,6 +63,7 @@
 
     (it "should have configured Auto-Dark"
       (expect auto-dark-themes :to-be nil)
+      ;; And _now_ these have their standard values.
       (expect auto-dark-dark-theme :to-be 'wombat)
       (expect auto-dark-light-theme :to-be 'leuven))
 

--- a/tests/initialization/defaults.el
+++ b/tests/initialization/defaults.el
@@ -1,0 +1,70 @@
+;;; defaults.el --- Tests that need to be run in a fresh instance -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; This models the most common initialization style of Emacs, where Customize
+;; inserts a `custom-set-variables' form at the end of `user-init-file'.
+
+;; 1. `package-initialize' is called, then
+;; 2. `user-init-file' is loaded, which has
+;;   a. some initialization of `auto-dark-mode' and
+;;   b. `custom-set-variables' at the end.
+
+;;; Code:
+
+(require 'auto-dark-initialize)
+(require 'buttercup)
+
+;; To silence “reference to free variable” warnings
+(defvar auto-dark-allow-osascript)
+(defvar auto-dark-allow-powershell)
+(defvar auto-dark-dark-theme)
+(defvar auto-dark-detection-method)
+(defvar auto-dark-light-theme)
+(defvar auto-dark-polling-interval-seconds)
+(defvar auto-dark-themes)
+
+(describe "Emacs’s de-facto initialization with old theme vars"
+  (before-all
+    (auto-dark-initialize-after-early-init '(auto-dark-autoloads)))
+
+  (describe "after ‘package-initialize’ is called"
+    (it "should not have enabled the themes yet"
+      (expect custom-enabled-themes :to-be ()))
+    (it "should not have bound Auto-Dark variables"
+      (expect (boundp 'auto-dark-allow-osascript) :to-be nil)
+      (expect (boundp 'auto-dark-allow-powershell) :to-be nil)
+      (expect (boundp 'auto-dark-dark-theme) :to-be nil)
+      (expect (boundp 'auto-dark-detection-method) :to-be nil)
+      (expect (boundp 'auto-dark-light-theme) :to-be nil)
+      (expect (boundp 'auto-dark-polling-interval-seconds) :to-be nil)
+      (expect (boundp 'auto-dark-themes) :to-be nil)))
+
+  (describe "before ‘custom-set-variables’ is called"
+    (before-all
+      (auto-dark-mode 1))
+
+    (it "should not have enabled the themes yet"
+      (expect custom-enabled-themes :to-equal ()))
+    (it "should have bound Auto-Dark variables to their standard values"
+      (expect auto-dark-allow-osascript :to-be nil)
+      (expect auto-dark-allow-powershell :to-be nil)
+      (expect (boundp 'auto-dark-detection-method) :to-be-truthy)
+      (expect auto-dark-polling-interval-seconds :to-be 5)
+      (expect auto-dark-themes :to-be nil)
+      (expect auto-dark-dark-theme :to-be 'wombat)
+      (expect auto-dark-light-theme :to-be 'leuven)))
+
+  (describe "after ‘user-init-file’ is loaded"
+    (before-all
+      (auto-dark-initialize-finish))
+
+    (it "should have configured Auto-Dark"
+      (expect auto-dark-themes :to-be nil)
+      (expect auto-dark-dark-theme :to-be 'wombat)
+      (expect auto-dark-light-theme :to-be 'leuven))
+
+    (it "should have enabled the correct themes"
+      (expect custom-enabled-themes :to-be-in '((wombat) (leuven))))))
+
+;;; defaults.el ends here

--- a/tests/initialization/early-init.el
+++ b/tests/initialization/early-init.el
@@ -57,8 +57,10 @@
       (expect (boundp 'auto-dark-detection-method) :to-be-truthy)
       (expect auto-dark-polling-interval-seconds :to-be 5)
       (expect auto-dark-themes :to-equal '((tsdh-dark) (tsdh-light)))
-      (expect auto-dark-dark-theme :to-be 'wombat)
-      (expect auto-dark-light-theme :to-be 'leuven)))
+      ;; These two are handled specially – they aren’t set to their defaults
+      ;; until after initialization.
+      (expect (boundp 'auto-dark-dark-theme) :to-be nil)
+      (expect (boundp 'auto-dark-light-theme) :to-be nil)))
 
   ;; FIXME: Make sure this is always in a particular mode, or check for either set.
   (describe "after-enabling"
@@ -72,7 +74,9 @@
       (expect (boundp 'auto-dark-detection-method) :to-be-truthy)
       (expect auto-dark-polling-interval-seconds :to-be 5)
       (expect auto-dark-themes :to-equal '((tsdh-dark) (tsdh-light)))
-      (expect auto-dark-dark-theme :to-be 'wombat)
-      (expect auto-dark-light-theme :to-be 'leuven))))
+      ;; These two are handled specially – they aren’t set to their defaults
+      ;; until after initialization.
+      (expect (boundp 'auto-dark-dark-theme) :to-be nil)
+      (expect (boundp 'auto-dark-light-theme) :to-be nil))))
 
 ;;; early-init.el ends here

--- a/tests/initialization/early-init.el
+++ b/tests/initialization/early-init.el
@@ -1,0 +1,78 @@
+;;; early-init.el --- Customize in early-init -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; This is more of an edge case, but it customizes the variables in early init,
+;; and then enables the package in regular init.
+
+;;; Code:
+
+(require 'auto-dark-initialize)
+(require 'buttercup)
+
+;; To silence “reference to free variable” warnings
+(defvar auto-dark-themes)
+
+(describe "customization in early init"
+  (before-all
+    (auto-dark-initialize-start)
+    (custom-set-variables
+     '(auto-dark-themes '((tsdh-dark) (tsdh-light)))))
+
+  (describe "in early init"
+    (it "should not have enabled the themes yet"
+      (expect custom-enabled-themes :to-be ())
+      (expect (boundp 'auto-dark-themes) :to-be nil))
+    (it "should not have bound Auto-Dark variables"
+      (expect (boundp 'auto-dark-allow-osascript) :to-be nil)
+      (expect (boundp 'auto-dark-allow-powershell) :to-be nil)
+      (expect (boundp 'auto-dark-dark-theme) :to-be nil)
+      (expect (boundp 'auto-dark-detection-method) :to-be nil)
+      (expect (boundp 'auto-dark-light-theme) :to-be nil)
+      (expect (boundp 'auto-dark-polling-interval-seconds) :to-be nil)
+      (expect (boundp 'auto-dark-themes) :to-be nil)))
+
+  (describe "after early init"
+    (before-all
+      (auto-dark-initialize-after-early-init '(auto-dark-autoloads)))
+    (it "should not have enabled the themes yet"
+      (expect custom-enabled-themes :to-be ()))
+    (it "should not have bound Auto-Dark variables"
+      (expect (boundp 'auto-dark-allow-osascript) :to-be nil)
+      (expect (boundp 'auto-dark-allow-powershell) :to-be nil)
+      (expect (boundp 'auto-dark-dark-theme) :to-be nil)
+      (expect (boundp 'auto-dark-detection-method) :to-be nil)
+      (expect (boundp 'auto-dark-light-theme) :to-be nil)
+      (expect (boundp 'auto-dark-polling-interval-seconds) :to-be nil)
+      (expect (boundp 'auto-dark-themes) :to-be nil)))
+
+  (describe "after package is loaded"
+    (before-all
+      (require 'auto-dark))
+    (it "should not have enabled the themes yet"
+      (expect custom-enabled-themes :to-be ()))
+    (it "should have bound Auto-Dark variables"
+      (expect auto-dark-allow-osascript :to-be nil)
+      (expect auto-dark-allow-powershell :to-be nil)
+      (expect (boundp 'auto-dark-detection-method) :to-be-truthy)
+      (expect auto-dark-polling-interval-seconds :to-be 5)
+      (expect auto-dark-themes :to-equal '((tsdh-dark) (tsdh-light)))
+      (expect auto-dark-dark-theme :to-be 'wombat)
+      (expect auto-dark-light-theme :to-be 'leuven)))
+
+  ;; FIXME: Make sure this is always in a particular mode, or check for either set.
+  (describe "after-enabling"
+    (before-all
+      (auto-dark-mode 1))
+    (it "themes should be enabled"
+      (expect custom-enabled-themes :to-be-in '((tsdh-dark) (tsdh-light))))
+    (it "Auto-Dark variables should be unchanged"
+      (expect auto-dark-allow-osascript :to-be nil)
+      (expect auto-dark-allow-powershell :to-be nil)
+      (expect (boundp 'auto-dark-detection-method) :to-be-truthy)
+      (expect auto-dark-polling-interval-seconds :to-be 5)
+      (expect auto-dark-themes :to-equal '((tsdh-dark) (tsdh-light)))
+      (expect auto-dark-dark-theme :to-be 'wombat)
+      (expect auto-dark-light-theme :to-be 'leuven))))
+
+;;; early-init.el ends here

--- a/tests/initialization/use-package-config.el
+++ b/tests/initialization/use-package-config.el
@@ -1,0 +1,60 @@
+;;; use-package-config.el --- Use-package with :config -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; This tests a common `use-package' style of initialization.
+
+;;; Code:
+
+(require 'auto-dark-initialize)
+(require 'buttercup)
+
+(describe "‘use-package’ initialization with :config"
+  (before-all
+    (auto-dark-initialize-after-early-init '(auto-dark-autoloads)))
+
+  (describe "after ‘package-initialize’ is called"
+    (it "should not have enabled the themes yet"
+      (expect custom-enabled-themes :to-be ()))
+    (it "should not have bound Auto-Dark variables"
+      (expect (boundp 'auto-dark-allow-osascript) :to-be nil)
+      (expect (boundp 'auto-dark-allow-powershell) :to-be nil)
+      (expect (boundp 'auto-dark-dark-theme) :to-be nil)
+      (expect (boundp 'auto-dark-detection-method) :to-be nil)
+      (expect (boundp 'auto-dark-light-theme) :to-be nil)
+      (expect (boundp 'auto-dark-polling-interval-seconds) :to-be nil)
+      (expect (boundp 'auto-dark-themes) :to-be nil)))
+
+  (describe "after ‘user-init-file’ is loaded"
+    (before-all
+      (use-package auto-dark
+        :custom (auto-dark-themes '((tsdh-dark) (tsdh-light)))
+        :config (auto-dark-mode)))
+
+    (it "should have configured Auto-Dark"
+      (expect auto-dark-allow-osascript :to-be nil)
+      (expect auto-dark-allow-powershell :to-be nil)
+      (expect (boundp 'auto-dark-detection-method) :to-be-truthy)
+      (expect auto-dark-polling-interval-seconds :to-be 5)
+      (expect auto-dark-themes :to-equal '((tsdh-dark) (tsdh-light)))
+      (expect auto-dark-dark-theme :to-be 'wombat)
+      (expect auto-dark-light-theme :to-be 'leuven))
+    (it "should have enabled the themes"
+      (expect custom-enabled-themes :to-be-in '((tsdh-dark) (tsdh-light)))))
+
+  (describe "after init"
+    (before-all
+      (auto-dark-initialize-finish))
+
+    (it "should have configured Auto-Dark"
+      (expect auto-dark-allow-osascript :to-be nil)
+      (expect auto-dark-allow-powershell :to-be nil)
+      (expect (boundp 'auto-dark-detection-method) :to-be-truthy)
+      (expect auto-dark-polling-interval-seconds :to-be 5)
+      (expect auto-dark-themes :to-equal '((tsdh-dark) (tsdh-light)))
+      (expect auto-dark-dark-theme :to-be 'wombat)
+      (expect auto-dark-light-theme :to-be 'leuven))
+    (it "should have enabled the themes"
+      (expect custom-enabled-themes :to-be-in '((tsdh-dark) (tsdh-light))))))
+
+;;; use-package-config.el ends here

--- a/tests/initialization/use-package-config.el
+++ b/tests/initialization/use-package-config.el
@@ -37,8 +37,10 @@
       (expect (boundp 'auto-dark-detection-method) :to-be-truthy)
       (expect auto-dark-polling-interval-seconds :to-be 5)
       (expect auto-dark-themes :to-equal '((tsdh-dark) (tsdh-light)))
-      (expect auto-dark-dark-theme :to-be 'wombat)
-      (expect auto-dark-light-theme :to-be 'leuven))
+      ;; These two are handled specially – they aren’t set to their defaults
+      ;; until after initialization.
+      (expect (boundp 'auto-dark-dark-theme) :to-be nil)
+      (expect (boundp 'auto-dark-light-theme) :to-be nil))
     (it "should have enabled the themes"
       (expect custom-enabled-themes :to-be-in '((tsdh-dark) (tsdh-light)))))
 

--- a/tests/initialization/use-package-init.el
+++ b/tests/initialization/use-package-init.el
@@ -1,0 +1,53 @@
+;;; use-package-init.el --- Use-package with :init -*- lexical-binding: t; -*-
+
+;;; Commentary:
+
+;; This tests a common `use-package' style of initialization.
+
+;;; Code:
+
+(require 'auto-dark-initialize)
+(require 'buttercup)
+
+;; To silence “reference to free variable” warnings
+(defvar auto-dark-allow-osascript)
+(defvar auto-dark-allow-powershell)
+(defvar auto-dark-dark-theme)
+(defvar auto-dark-light-theme)
+(defvar auto-dark-polling-interval-seconds)
+(defvar auto-dark-themes)
+
+(describe "‘use-package’ initialization with :init"
+  (before-all
+    (auto-dark-initialize-after-early-init '(auto-dark-autoloads)))
+
+  (describe "after ‘package-initialize’ is called"
+    (it "should not have enabled the themes yet"
+      (expect custom-enabled-themes :to-be ()))
+    (it "should not have bound Auto-Dark variables"
+      (expect (boundp 'auto-dark-allow-osascript) :to-be nil)
+      (expect (boundp 'auto-dark-allow-powershell) :to-be nil)
+      (expect (boundp 'auto-dark-dark-theme) :to-be nil)
+      (expect (boundp 'auto-dark-detection-method) :to-be nil)
+      (expect (boundp 'auto-dark-light-theme) :to-be nil)
+      (expect (boundp 'auto-dark-polling-interval-seconds) :to-be nil)
+      (expect (boundp 'auto-dark-themes) :to-be nil)))
+
+  (describe "after ‘user-init-file’ is loaded"
+    (before-all
+      (use-package auto-dark
+        :custom (auto-dark-themes '((tsdh-dark) (tsdh-light)))
+        :config (auto-dark-mode)))
+
+    (it "should have configured Auto-Dark"
+      (expect auto-dark-allow-osascript :to-be nil)
+      (expect auto-dark-allow-powershell :to-be nil)
+      (expect (boundp 'auto-dark-detection-method) :to-be-truthy)
+      (expect auto-dark-polling-interval-seconds :to-be 5)
+      (expect auto-dark-themes :to-equal '((tsdh-dark) (tsdh-light)))
+      (expect auto-dark-dark-theme :to-be 'wombat)
+      (expect auto-dark-light-theme :to-be 'leuven))
+    (it "should have enabled the themes"
+      (expect custom-enabled-themes :to-be-in '((tsdh-dark) (tsdh-light))))))
+
+;;; use-package-init.el ends here

--- a/tests/initialization/use-package-init.el
+++ b/tests/initialization/use-package-init.el
@@ -45,8 +45,10 @@
       (expect (boundp 'auto-dark-detection-method) :to-be-truthy)
       (expect auto-dark-polling-interval-seconds :to-be 5)
       (expect auto-dark-themes :to-equal '((tsdh-dark) (tsdh-light)))
-      (expect auto-dark-dark-theme :to-be 'wombat)
-      (expect auto-dark-light-theme :to-be 'leuven))
+      ;; These two are handled specially – they aren’t set to their defaults
+      ;; until after initialization.
+      (expect (boundp 'auto-dark-dark-theme) :to-be nil)
+      (expect (boundp 'auto-dark-light-theme) :to-be nil))
     (it "should have enabled the themes"
       (expect custom-enabled-themes :to-be-in '((tsdh-dark) (tsdh-light))))))
 


### PR DESCRIPTION
This does a number of things, so it may be worth reviewing commit-by-commit.

First, it introduces some layered infrastructure:

1. Buttercup test suites, with some basic tests and other ones to try out different init styles;
2. Eldev, for Emacs package management;
3. Nix, for coördination (e.g., running multiple test configurations, building against multiple Emacs distributions); and
4. garnix, for CI.

They are somewhat independent (e.g., you could rip out the unit tests and keep the rest), but it’s easiest to remove the higher-numbered layers first if they are undesirable. E.g., garnix could be replaced with GitHub workflows (but at the cost of more configuration, which I’m not interested in writing).

The other commits fix the complaints:
- a bunch of small changes to appease various Elisp linters, particularly `package-lint`;
- pre-loading themes & updating state immediately (which address parts of #64);
- setting themes even when Auto-Dark can’t determine a detection method (technically a fix for #66, but there are other things in that, which will be included in an updated #62, and this also addresses part of #73); and
- defer initializing old theme vars until after init, which can avoid a “flicker” to the old theme var values before the new theme var kicks in.