### PR TITLE
change pattern matching logic for dbus

### DIFF
--- a/auto-dark.el
+++ b/auto-dark.el
@@ -308,9 +308,8 @@ to change the theme."
            (when (and (string= path "org.freedesktop.appearance")
                       (string= var "color-scheme"))
              (pcase (car val)
-               (0 nil)
                (1 (auto-dark--set-theme 'dark))
-               (2 (auto-dark--set-theme 'light))))))))
+               ((or 0 2) (auto-dark--set-theme 'light))))))))
 
 (defun auto-dark--unregister-dbus-listener ()
   "Unregister our callback function with D-Bus.


### PR DESCRIPTION
GNOME Shell sends `org.freedesktop.appearance` dbus signal with key value pair `color-scheme` `0` when switching from dark to light modes, not `2`. An additional `org.gnome.desktop.interface` `color-scheme` signal is sent with the value `default`, suggesting that GNOME considers a light color scheme to be the default when there is "No preference." Instead of checking for a value of 2 for the key `org.freedesktop.appearance` `color-scheme`, the dbus listener object can switch to the light variant for values `0` or `2`.