### PR TITLE
DBus: Let "no preference" be light again

### DIFF
--- a/auto-dark.el
+++ b/auto-dark.el
@@ -128,9 +128,8 @@ this is less efficient, but works for non-GUI Emacs."
                   "/org/freedesktop/portal/desktop"
                   "org.freedesktop.portal.Settings" "Read"
                   "org.freedesktop.appearance" "color-scheme")))
-    (0 nil)
     (1 'dark)
-    (2 'light)))
+    ((or 0 2) 'light)))
 
 (defun auto-dark--is-dark-mode-powershell ()
   "Invoke powershell using Emacs using external shell command."


### PR DESCRIPTION
The value `0` in the `color-scheme` spec[1] means "No preference". The way `auto-dark-mode` historically has interpreted "No preference" is as light mode. This was true both in `auto-dark--current-mode-dbus` and `auto-dark--register-dbus-listener` up until 3bacb8f3998a.

In 3bacb8f3998a this logic changed in `auto-dark--current-mode-dbus` but was *kept* in `auto-dark--register-dbus-listener`. This means that I now need to flip the light- and dark mode switch in the OS twice once I've started Emacs to make the theme in Emacs be in sync with the OS.

Revert the logic change in `auto-dark--current-mode-dbus` introduced in 3bacb8f3998a to make sure it stays in sync with
`auto-dark--register-dbus-listener`.

1: https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Settings.html