### PR TITLE
fix: handle themes declared but not loaded (e.g. modus-themes v5 #96)

### DIFF
--- a/auto-dark.el
+++ b/auto-dark.el
@@ -6,7 +6,7 @@
 ;;         Jonathan Arnett <jonathan.arnett@protonmail.com>
 ;;         Greg Pfeil <greg@technomadic.org>
 ;; Created: July 16 2019
-;; Version: 0.13.9
+;; Version: 0.13.10
 ;; Keywords: macos, windows, linux, themes, tools, faces
 ;; URL: https://github.com/LionyxML/auto-dark-emacs
 ;; Package-Requires: ((emacs "24.4"))
@@ -234,10 +234,31 @@ This will load themes if necessary."
           custom-enabled-themes)
     (let ((failures (mapcan (lambda (theme)
                               (condition-case nil
-                                  ;; Enable instead of load when possible.
-                                  (ignore (if (custom-theme-p theme)
-                                              (enable-theme theme)
-                                            (load-theme theme)))
+                                  ;; We use `enable-theme' instead of
+                                  ;; `load-theme' when possible because:
+                                  ;; 1. `load-theme' prompts about
+                                  ;;    `custom-safe-themes' which would
+                                  ;;    break init or fire on every
+                                  ;;    switch (#64, #82).
+                                  ;; 2. `enable-theme' is faster since it
+                                  ;;    skips re-evaluating the theme file.
+                                  ;; The pre-load in `:set' below handles
+                                  ;; the safety prompt once up front.
+                                  ;;
+                                  ;; However, we check `theme-settings'
+                                  ;; rather than `custom-theme-p' because
+                                  ;; some theme libraries (e.g.
+                                  ;; modus-themes v5) eagerly call
+                                  ;; `custom-declare-theme' at
+                                  ;; `require'-time for all their themes.
+                                  ;; This makes `custom-theme-p' return t
+                                  ;; even though no face specs have been
+                                  ;; computed yet.  `enable-theme' on such
+                                  ;; a theme is a no-op (#96).
+                                  (ignore
+                                   (if (get theme 'theme-settings)
+                                       (enable-theme theme)
+                                     (load-theme theme t)))
                                 (error (list theme))))
                             (reverse full-themes))))
       (when failures
@@ -423,12 +444,20 @@ to t."
                 (repeat :tag "Dark" symbol)
                 (repeat :tag "Light" symbol)))
   :set (lambda (symbol value)
-         ;; Pre-load any themes used by Auto Dark (to force prompts for
-         ;; ‘custom-safe-themes’ while the user is interacting with Auto Dark,
-         ;; rather than at initialization or ‘frame-background-mode’ charge).
+         ;; Pre-load themes so that:
+         ;; 1. `custom-safe-themes’ prompts happen here (during
+         ;;    customization) rather than at init or mode-switch
+         ;;    time (#64, #67, #82).
+         ;; 2. `auto-dark--enable-themes’ can later use the fast
+         ;;    `enable-theme’ path instead of `load-theme’.
+         ;; We check `theme-settings’ instead of `custom-theme-p’
+         ;; because some theme libraries (e.g. modus-themes v5)
+         ;; eagerly declare all their themes at `require’-time
+         ;; without loading them, which would cause this pre-load
+         ;; to be skipped (#96).
          (mapc (lambda (mode-themes)
                  (mapc (lambda (theme)
-                         (unless (custom-theme-p theme)
+                         (unless (get theme 'theme-settings)
                            (load-theme theme nil t)))
                        mode-themes))
                value)

--- a/tests/basic.el
+++ b/tests/basic.el
@@ -52,6 +52,54 @@
   (it "should invert the current appearance and again"
     (expect custom-enabled-themes :to-equal '(wombat))))
 
+;; Test for themes that are declared but not fully loaded (issue #96).
+;; modus-themes v5 eagerly calls `custom-declare-theme' for all its themes
+;; when `(require 'modus-themes)' runs, making `custom-theme-p' return t
+;; even though no face specs have been computed (`theme-settings' is nil).
+;; auto-dark must detect this and use `load-theme' instead of `enable-theme'.
+
+(describe "declared-but-not-loaded themes (issue #96)"
+  :var (test-dark-theme test-light-theme)
+  (before-all
+    ;; Pick two built-in themes that haven't been loaded yet in this session.
+    ;; We'll artificially "declare" the dark one (simulating what modus-themes
+    ;; does at require-time) so it's known but has no face specs.
+    (setq test-dark-theme 'tsdh-dark
+          test-light-theme 'tsdh-light)
+    ;; Make sure our test themes are in a clean state.
+    (mapc #'disable-theme (list test-dark-theme test-light-theme))
+    ;; Remove any prior theme-settings so we start fresh.
+    (put test-dark-theme 'theme-settings nil)
+    ;; Simulate modus-themes: declare the theme without loading it.
+    ;; This adds it to `custom-known-themes' (so `custom-theme-p' returns t)
+    ;; but does NOT populate `theme-settings' (no face specs).
+    (unless (custom-theme-p test-dark-theme)
+      (custom-declare-theme test-dark-theme
+                            (custom-make-theme-feature test-dark-theme)))
+    ;; Sanity check: the theme is "known" but has no settings.
+    (expect (custom-theme-p test-dark-theme) :to-be-truthy)
+    (expect (get test-dark-theme 'theme-settings) :to-be nil))
+
+  (it "pre-load should load a declared-but-not-loaded theme"
+    ;; The :set handler must not skip pre-loading just because the theme
+    ;; is declared.
+    (custom-set-variables
+     `(auto-dark-themes '((,test-dark-theme) (,test-light-theme))))
+    ;; After :set runs the pre-load, the theme should have settings.
+    (expect (get test-dark-theme 'theme-settings) :to-be-truthy))
+
+  (it "enable-themes should activate the theme correctly"
+    ;; The current mode is light (from earlier tests), so toggle to dark.
+    (auto-dark-toggle-appearance)
+    (expect custom-enabled-themes :to-equal (list test-dark-theme)))
+
+  (after-all
+    ;; Clean up: switch back to a known state.
+    (auto-dark-toggle-appearance)
+    (mapc #'disable-theme (list test-dark-theme test-light-theme))
+    (custom-set-variables
+     '(auto-dark-themes '((wombat) (leuven))))))
+
 ;; Restore the original state
 (unless auto-dark-tests--original-state
   (auto-dark-mode -1))


### PR DESCRIPTION
modus-themes v5 eagerly calls `custom-declare-theme' for all its themes at `require'-time. This makes `custom-theme-p' return t even though no face specs have been computed (`theme-settings' is nil).

auto-dark relied on `custom-theme-p' in two places:
1. The `:set' pre-load guard — skipped loading, so face specs were never computed.
2. The switch logic in `auto-dark--enable-themes' — called `enable-theme' on a theme with no settings, which is a no-op.

Both now check `(get theme 'theme-settings)' instead, which distinguishes "fully loaded" from "merely declared". This preserves the `enable-theme' optimization (avoiding `custom-safe-themes' prompts on every switch, #64, #82) while fixing modus-themes, ef-themes, and other derivatives.

Added a regression test that simulates the declare-without-load pattern.

Fixes #96